### PR TITLE
Speed up OSM way processing

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/edgenaming/SidewalkNamer.java
+++ b/application/src/ext/java/org/opentripplanner/ext/edgenaming/SidewalkNamer.java
@@ -21,7 +21,6 @@ import org.opentripplanner.osm.model.OsmEntity;
 import org.opentripplanner.osm.model.OsmLevel;
 import org.opentripplanner.osm.model.OsmWay;
 import org.opentripplanner.street.geometry.GeometryUtils;
-import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +96,7 @@ class SidewalkNamer implements EdgeNamer {
    */
   public boolean assignNameToEdge(EdgeOnLevel sidewalkOnLevel, Geometry buffer) {
     var sidewalk = sidewalkOnLevel.edge();
-    var sidewalkLength = SphericalDistanceLibrary.length(sidewalk.getGeometry());
+    var sidewalkLength = GeometryUtils.sumDistances(sidewalk.getGeometry());
 
     var candidates = streetIndex.query(buffer);
 
@@ -185,7 +184,7 @@ class SidewalkNamer implements EdgeNamer {
 
     private double length(Geometry intersection) {
       return switch (intersection) {
-        case LineString ls -> SphericalDistanceLibrary.length(ls);
+        case LineString ls -> GeometryUtils.sumDistances(ls);
         case MultiLineString mls -> GeometryUtils.getLineStrings(mls)
           .stream()
           .mapToDouble(this::intersectionLength)

--- a/application/src/main/java/org/opentripplanner/api/model/geometry/EncodedPolyline.java
+++ b/application/src/main/java/org/opentripplanner/api/model/geometry/EncodedPolyline.java
@@ -2,7 +2,6 @@ package org.opentripplanner.api.model.geometry;
 
 import java.util.Objects;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.geometry.PolylineEncoder;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
@@ -82,13 +81,7 @@ public final class EncodedPolyline {
 
   private void calculateDistance() {
     if (distance_m == NOT_SET) {
-      // Optimization: In the case of a LineString, it is more efficient to compute the distance
-      // from the coordinate sequence than the coordinates (less intermediate objects creation)
-      if (geometry instanceof LineString ls) {
-        distance_m = (int) GeometryUtils.sumDistances(ls.getCoordinateSequence());
-      } else {
-        distance_m = (int) GeometryUtils.sumDistances(geometry.getCoordinates());
-      }
+      distance_m = (int) GeometryUtils.sumDistances(geometry);
     }
   }
 }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/OsmBoardingLocationsModule.java
@@ -314,7 +314,7 @@ public class OsmBoardingLocationsModule implements GraphBuilderModule {
       .withToVertex(to)
       .withGeometry(line)
       .withName(LOCALIZED_PLATFORM_NAME)
-      .withMeterLength(SphericalDistanceLibrary.length(line))
+      .withMeterLength(GeometryUtils.sumDistances(line))
       .withPermission(StreetTraversalPermission.PEDESTRIAN_AND_BICYCLE)
       .withBack(false)
       .buildAndConnect();

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/ElevatorProcessor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/ElevatorProcessor.java
@@ -207,7 +207,7 @@ class ElevatorProcessor {
       }
       List<OsmLevel> nodeLevels = osmdb.getLevelsForEntity(way);
       List<Long> nodes = Arrays.stream(way.getNodeRefs().toArray())
-        .filter(nodeRef -> vertexGenerator.intersectionNodes().get(nodeRef) != null)
+        .filter(vertexGenerator::isIntersectionNode)
         .boxed()
         .toList();
 
@@ -252,7 +252,7 @@ class ElevatorProcessor {
       List<ElevatorHopVertex> elevatorHopVertices = new ArrayList<>();
       for (int i = 0; i < nodes.size(); i++) {
         Long node = nodes.get(i);
-        var sourceVertex = vertexGenerator.intersectionNodes().get(node);
+        var sourceVertex = vertexGenerator.getIntersectionVertex(node);
         OsmLevel level = nodeLevels.get(i);
         createElevatorVertices(
           elevatorHopVertices,

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.opentripplanner.core.model.i18n.I18NString;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
@@ -43,7 +42,6 @@ import org.opentripplanner.service.vehicleparking.VehicleParkingRepository;
 import org.opentripplanner.service.vehicleparking.model.VehicleParking;
 import org.opentripplanner.street.StreetRepository;
 import org.opentripplanner.street.geometry.GeometryUtils;
-import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.StreetModelDetails;
 import org.opentripplanner.street.model.StreetTraversalPermission;
@@ -241,18 +239,6 @@ public class OsmModule implements GraphBuilderModule {
     params.edgeNamer().finalizeNames();
   }
 
-  /**
-   * Returns the length of the geometry in meters.
-   */
-  private static double getGeometryLengthMeters(Geometry geometry) {
-    Coordinate[] coordinates = geometry.getCoordinates();
-    double d = 0;
-    for (int i = 1; i < coordinates.length; ++i) {
-      d += SphericalDistanceLibrary.distance(coordinates[i - 1], coordinates[i]);
-    }
-    return d;
-  }
-
   private List<OsmAreaGroup> groupAreas(
     OsmDatabase osmdb,
     Collection<OsmArea> areas,
@@ -429,7 +415,7 @@ public class OsmModule implements GraphBuilderModule {
         // where the current edge might end
         OsmNode osmEndNode = osmdb.getNode(endNode);
 
-        LineString geometry;
+        LineString lineString;
 
         /*
          * We split segments at intersections, self-intersections, nodes with ele tags, and transit stops;
@@ -453,7 +439,7 @@ public class OsmModule implements GraphBuilderModule {
           segmentCoordinates.add(osmEndNode.lon);
           segmentCoordinates.add(osmEndNode.lat);
 
-          geometry = GeometryUtils.makeLineString(segmentCoordinates.toArray());
+          lineString = GeometryUtils.makeLineString(segmentCoordinates.toArray());
           segmentCoordinates.clear();
         } else {
           segmentCoordinates.add(osmEndNode.lon);
@@ -486,7 +472,7 @@ public class OsmModule implements GraphBuilderModule {
           // However, intersection vertices are created in this loop.
           continue;
         } else if (way.isEscalator()) {
-          var length = getGeometryLengthMeters(geometry);
+          var length = GeometryUtils.sumDistances(lineString);
           EscalatorEdgePair escalatorEdgePair = escalatorProcessor.buildEscalatorEdge(
             way,
             length,
@@ -509,7 +495,7 @@ public class OsmModule implements GraphBuilderModule {
             i,
             forwardPermission,
             backwardPermission,
-            geometry
+            lineString
           );
 
           params.edgeNamer().recordEdges(way, streets, osmdb);
@@ -665,7 +651,7 @@ public class OsmModule implements GraphBuilderModule {
     LineString backGeometry = geometry.reverse();
     StreetEdge street = null;
     StreetEdge backStreet = null;
-    double length = getGeometryLengthMeters(geometry);
+    double length = GeometryUtils.sumDistances(geometry);
 
     if (forwardPermission.allowsAnything()) {
       street = getEdgeForStreet(

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/OsmModule.java
@@ -427,7 +427,7 @@ public class OsmModule implements GraphBuilderModule {
         }
 
         if (
-          vertexGenerator.intersectionNodes().containsKey(endNode) ||
+          vertexGenerator.isIntersectionNode(endNode) ||
           i == nodes.size() - 2 ||
           nodes.subList(0, i).contains(nodes.get(i)) ||
           osmEndNode.hasTag("ele") ||

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexGenerator.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexGenerator.java
@@ -324,11 +324,14 @@ class VertexGenerator {
   }
 
   /**
-   * Return the graph vertex already created for the given intersection node id, or null if the
-   * node is not an intersection node, or a vertex hasn't been created for it yet.
+   * Return the graph vertex already created for the given intersection node id. Throws an exception
+   * if the node is not an intersection node, or a vertex hasn't been created for it yet.
    */
   IntersectionVertex getIntersectionVertex(long nodeId) {
-    return Objects.requireNonNull(intersectionNodes.get(nodeId), "Intersection vertex not found.");
+    return Objects.requireNonNull(
+      intersectionNodes.get(nodeId),
+      "Intersection vertex %s not found.".formatted(nodeId)
+    );
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexGenerator.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexGenerator.java
@@ -6,11 +6,14 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import gnu.trove.list.TLongList;
+import gnu.trove.map.TLongObjectMap;
+import gnu.trove.map.hash.TLongObjectHashMap;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.core.model.accessibility.Accessibility;
@@ -40,7 +43,7 @@ class VertexGenerator {
 
   private static final String NODE_LABEL_FORMAT = "osm:node:%d";
 
-  private final Map<Long, IntersectionVertex> intersectionNodes = new HashMap<>();
+  private final TLongObjectMap<IntersectionVertex> intersectionNodes = new TLongObjectHashMap<>();
 
   private final HashMap<Long, Map<OsmElevatorKey, OsmElevatorVertex>> elevatorNodes =
     new HashMap<>();
@@ -313,10 +316,19 @@ class VertexGenerator {
   }
 
   /**
-   * Track OSM nodes that will become graph vertices because they appear in multiple OSM ways
+   * Returns whether the given OSM node id is a shared intersection node, i.e. it appears in more
+   * than one OSM way (or way/area boundary) and therefore needs to become a graph vertex.
    */
-  Map<Long, IntersectionVertex> intersectionNodes() {
-    return intersectionNodes;
+  boolean isIntersectionNode(long nodeId) {
+    return intersectionNodes.containsKey(nodeId);
+  }
+
+  /**
+   * Return the graph vertex already created for the given intersection node id, or null if the
+   * node is not an intersection node, or a vertex hasn't been created for it yet.
+   */
+  IntersectionVertex getIntersectionVertex(long nodeId) {
+    return Objects.requireNonNull(intersectionNodes.get(nodeId), "Intersection vertex not found.");
   }
 
   /**

--- a/street/src/main/java/org/opentripplanner/street/geometry/GeometryUtils.java
+++ b/street/src/main/java/org/opentripplanner/street/geometry/GeometryUtils.java
@@ -315,6 +315,19 @@ public class GeometryUtils {
     return Arrays.stream(envelopes);
   }
 
+  /**
+   * Returns the length of the geometry in meters.
+   */
+  public static double sumDistances(Geometry geometry) {
+    // Optimization: In the case of a LineString, it is more efficient to compute the distance
+    // from the coordinate sequence than the coordinates (less intermediate objects creation)
+    if (geometry instanceof LineString ls) {
+      return GeometryUtils.sumDistances(ls.getCoordinateSequence());
+    } else {
+      return GeometryUtils.sumDistances(geometry.getCoordinates());
+    }
+  }
+
   /// Returns the sum of the distances in between the pairs of coordinates in meters.
   /// If the number of coordinates is empty or just one(a point), then `0` is returned.
   public static double sumDistances(Coordinate[] coordinates) {

--- a/street/src/main/java/org/opentripplanner/street/geometry/SphericalDistanceLibrary.java
+++ b/street/src/main/java/org/opentripplanner/street/geometry/SphericalDistanceLibrary.java
@@ -126,22 +126,6 @@ public abstract class SphericalDistanceLibrary {
   }
 
   /**
-   * Compute the length of a polyline
-   *
-   * @param lineString The polyline in (longitude, latitude degrees).
-   * @return The length, in meters, of the linestring.
-   */
-  public static double length(LineString lineString) {
-    double accumulatedMeters = 0;
-
-    for (int i = 1; i < lineString.getNumPoints(); i++) {
-      accumulatedMeters += distance(lineString.getCoordinateN(i - 1), lineString.getCoordinateN(i));
-    }
-
-    return accumulatedMeters;
-  }
-
-  /**
    * Compute the (approximated) length of a polyline
    *
    * @param lineString The polyline in (longitude, latitude degrees).

--- a/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/StreetEdge.java
@@ -13,7 +13,6 @@ import org.opentripplanner.service.vehiclerental.street.geofencing.GeofencingInt
 import org.opentripplanner.street.geometry.DirectionUtils;
 import org.opentripplanner.street.geometry.EndpointContextLineString;
 import org.opentripplanner.street.geometry.GeometryUtils;
-import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.geometry.SplitLineString;
 import org.opentripplanner.street.linking.LinkingDirection;
 import org.opentripplanner.street.model.StreetTraversalPermission;
@@ -744,8 +743,8 @@ public class StreetEdge
     return lengthInMillimeter;
   }
 
-  static int defaultMillimeterLength(LineString geometry) {
-    return (int) (SphericalDistanceLibrary.length(geometry) * 1000);
+  static int defaultMillimeterLength(LineString lineString) {
+    return (int) (GeometryUtils.sumDistances(lineString) * 1000);
   }
 
   private State[] traverseWithGeofencing(State s0) {

--- a/street/src/test/java/org/opentripplanner/street/geometry/GeometryUtilsTest.java
+++ b/street/src/test/java/org/opentripplanner/street/geometry/GeometryUtilsTest.java
@@ -243,4 +243,20 @@ public class GeometryUtilsTest {
     var meters = GeometryUtils.sumDistances(coordinates);
     assertEquals(0.0, meters);
   }
+
+  @Test
+  void sumDistancesLineString() {
+    LineString line = GeometryUtils.makeLineString(BERLIN, HAMBURG);
+    var meters = GeometryUtils.sumDistances(line);
+    assertEquals(255_384.0, meters, 0.5);
+  }
+
+  @Test
+  void sumDistancesNonLineStringGeometry() {
+    var multiPoint = GeometryUtils.getGeometryFactory().createMultiPointFromCoords(
+      new Coordinate[] { BERLIN, HAMBURG }
+    );
+    var meters = GeometryUtils.sumDistances(multiPoint);
+    assertEquals(255_384.0, meters, 0.5);
+  }
 }

--- a/street/src/test/java/org/opentripplanner/street/geometry/SphericalDistanceLibraryTest.java
+++ b/street/src/test/java/org/opentripplanner/street/geometry/SphericalDistanceLibraryTest.java
@@ -27,7 +27,7 @@ class SphericalDistanceLibraryTest {
       geometryFactory.getCoordinateSequenceFactory();
     CoordinateSequence sequence = coordinateSequenceFactory.create(coordinates);
     LineString line = new LineString(sequence, geometryFactory);
-    double length = SphericalDistanceLibrary.length(line);
+    double length = GeometryUtils.sumDistances(line);
 
     // A nautical mile is 1852 meters, and is defined as one 1/60th of a degree longitude on the
     // equator. As this is an approximate calculation, we expect the real value to be within a


### PR DESCRIPTION
### Summary

Two small performance measures that together speed up the processing of OSM ways by around 10 percent.

### Issue

No linked issue — this is a self-contained performance refactor with no behavior change:

- `VertexGenerator` now stores intersection vertices in a `TLongObjectMap<IntersectionVertex>` (Trove) instead of `HashMap<Long, IntersectionVertex>`. This map is looked up for essentially every node of every way while building the street graph, so it's a hot path. The primitive map avoids boxing every OSM node id into a `Long` and avoids the virtual `hashCode()`/`equals()` dispatch and `Map.Entry` indirection a regular `HashMap` incurs.
- Introduced `GeometryUtils.sumDistances(Geometry)`, which for `LineString`s sums distances directly from the underlying `CoordinateSequence` instead of first materializing a `Coordinate[]` array. This replaces a duplicated, less efficient length calculation that was used when building street edges and escalator edges from OSM ways, and is now reused by a few other callers (`EncodedPolyline`, `SidewalkNamer`, `OsmBoardingLocationsModule`) as well.

### Unit tests

- Added `GeometryUtilsTest#sumDistancesLineString` and `#sumDistancesNonLineStringGeometry`, covering both branches of the new `sumDistances(Geometry)` method.
- Existing `VertexGenerator`/`OsmModule`/elevator/walkable-area/`EncodedPolyline`/`SidewalkNamer`/`OsmBoardingLocationsModule` test suites all pass unchanged, confirming this is behavior-preserving.
- No automated benchmark harness exists for the OSM import step; the ~10% improvement was measured manually.

### Documentation

N/A — internal implementation detail, no public API or configuration changes.