### PR TITLE
Speed up island pruning

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/IslandPruningModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/IslandPruningModule.java
@@ -191,12 +191,7 @@ public class IslandPruningModule implements GraphBuilderModule {
     boolean markIsolated,
     TraverseMode traverseMode
   ) {
-    Map<String, Integer> stats = new HashMap<>();
-
-    stats.put("isolated", 0);
-    stats.put("removed", 0);
-    stats.put("noThru", 0);
-    stats.put("restricted", 0);
+    var stats = new PruningStats();
 
     Subgraph largest = null;
     int maxSize = 0;
@@ -256,22 +251,22 @@ public class IslandPruningModule implements GraphBuilderModule {
       }
     }
     if (markIsolated) {
-      LOG.info("Detected {} isolated edges", stats.get("isolated"));
+      LOG.info("Detected {} isolated edges", stats.isolated());
     } else {
       LOG.info("Number of islands with stops: {}", islandsWithStops);
-      LOG.warn("Modified connectivity of {} islands with stops", islandsWithStopsChanged);
-      LOG.info("Removed {} edges", stats.get("removed"));
-      LOG.info("Removed traversal mode from {} edges", stats.get("restricted"));
-      LOG.info("Converted {} edges to noThruTraffic", stats.get("noThru"));
+      LOG.info("Modified connectivity of {} islands with stops", islandsWithStopsChanged);
+      LOG.info("Removed {} edges", stats.removed());
+      LOG.info("Removed traversal mode from {} edges", stats.restricted());
+      LOG.info("Converted {} edges to noThruTraffic", stats.noThru());
       issueStore.add(
         new GraphConnectivity(
           traverseMode,
           islands.size(),
           islandsWithStops,
           islandsWithStopsChanged,
-          stats.get("removed"),
-          stats.get("restricted"),
-          stats.get("noThru")
+          stats.removed(),
+          stats.restricted(),
+          stats.noThru()
         )
       );
     }
@@ -349,8 +344,7 @@ public class IslandPruningModule implements GraphBuilderModule {
         continue;
       }
       Subgraph subgraph = computeConnectedSubgraph(neighborsForVertex, gv, subgraphs, newgraphs);
-      for (Iterator<Vertex> vIter = subgraph.streetIterator(); vIter.hasNext(); ) {
-        Vertex subnode = vIter.next();
+      for (var subnode : subgraph.streetVertices()) {
         newgraphs.put(subnode, subgraph);
       }
       if (islands != null) {
@@ -364,7 +358,7 @@ public class IslandPruningModule implements GraphBuilderModule {
   private boolean restrictOrRemove(
     Subgraph island,
     Map<Edge, Boolean> isolated,
-    Map<String, Integer> stats,
+    PruningStats stats,
     boolean markIsolated,
     TraverseMode traverseMode
   ) {
@@ -372,14 +366,13 @@ public class IslandPruningModule implements GraphBuilderModule {
     int removed = 0;
     int restricted = 0;
     //iterate over the street vertex of the subgraph
-    for (Iterator<Vertex> vIter = island.streetIterator(); vIter.hasNext(); ) {
-      Vertex v = vIter.next();
+    for (Vertex v : island.streetVertices()) {
       Collection<Edge> outgoing = new ArrayList<>(v.getOutgoing());
       for (Edge e : outgoing) {
         if (e instanceof StreetEdge) {
           if (markIsolated) {
             isolated.put(e, true);
-            stats.put("isolated", stats.get("isolated") + 1);
+            stats.incrementIsolated();
           } else {
             StreetEdge pse = (StreetEdge) e;
             if (!isolated.containsKey(e)) {
@@ -404,7 +397,7 @@ public class IslandPruningModule implements GraphBuilderModule {
                 }
               }
               if (changed) {
-                stats.put("noThru", stats.get("noThru") + 1);
+                stats.incrementNoThru();
                 nothru++;
               }
             } else {
@@ -429,11 +422,11 @@ public class IslandPruningModule implements GraphBuilderModule {
               if (changed) {
                 if (permission == StreetTraversalPermission.NONE) {
                   graph.removeEdge(pse);
-                  stats.put("removed", stats.get("removed") + 1);
+                  stats.incrementRemoved();
                   removed++;
                 } else {
                   pse.setPermission(permission);
-                  stats.put("restricted", stats.get("restricted") + 1);
+                  stats.incrementRestricted();
                   restricted++;
                 }
               }
@@ -446,15 +439,11 @@ public class IslandPruningModule implements GraphBuilderModule {
       return false;
     }
 
-    if (stats.isEmpty()) {
-      return false;
-    }
     if (traverseMode == TraverseMode.WALK) {
       // note: do not unlink stop if only CAR mode is pruned
       // maybe this needs more logic for flex routing cases
       List<VertexLabel> stopLabels = new ArrayList<>();
-      for (Iterator<TransitStopVertex> vIter = island.stopIterator(); vIter.hasNext(); ) {
-        TransitStopVertex v = vIter.next();
+      for (var v : island.stopVertices()) {
         stopLabels.add(v.getLabel());
         Collection<Edge> edges = new ArrayList<>(v.getOutgoing());
         edges.addAll(v.getIncoming());

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/IslandPruningModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/IslandPruningModule.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +25,6 @@ import org.opentripplanner.street.model.edge.AreaGroup;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.street.model.vertex.StreetVertex;
-import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.model.vertex.VertexLabel;
 import org.opentripplanner.street.search.TraverseMode;
@@ -208,16 +206,13 @@ public class IslandPruningModule implements GraphBuilderModule {
     double adaptivePruningFactor = parameters.adaptivePruningFactor();
     int adaptivePruningDistance = parameters.adaptivePruningDistance();
 
-    int count = 0;
-    int islandsWithStops = 0;
-    int islandsWithStopsChanged = 0;
     for (Subgraph island : islands) {
       if (island == largest) {
         continue;
       }
       if (island.stopSize() > 0) {
         //for islands with stops
-        islandsWithStops++;
+        stats.incrementIslandsWithStops();
         boolean onlyFerry = island.hasOnlyFerryStops();
         int pruningThresholdWithStops = parameters.pruningThresholdIslandWithStops();
         // do not remove real islands which have only ferry stops
@@ -229,8 +224,8 @@ public class IslandPruningModule implements GraphBuilderModule {
 
           if (island.streetSize() * sizeCoeff < pruningThresholdWithStops) {
             if (restrictOrRemove(island, isolated, stats, markIsolated, traverseMode)) {
-              islandsWithStopsChanged++;
-              count++;
+              stats.incrementIslandsWithStopsChanged();
+              stats.incrementModifiedIslands();
             }
           }
         }
@@ -244,7 +239,7 @@ public class IslandPruningModule implements GraphBuilderModule {
             : 1.0;
           if (island.streetSize() * sizeCoeff < pruningThresholdWithoutStops) {
             if (restrictOrRemove(island, isolated, stats, markIsolated, traverseMode)) {
-              count++;
+              stats.incrementModifiedIslands();
             }
           }
         }
@@ -253,8 +248,8 @@ public class IslandPruningModule implements GraphBuilderModule {
     if (markIsolated) {
       LOG.info("Detected {} isolated edges", stats.isolated());
     } else {
-      LOG.info("Number of islands with stops: {}", islandsWithStops);
-      LOG.info("Modified connectivity of {} islands with stops", islandsWithStopsChanged);
+      LOG.info("Number of islands with stops: {}", stats.islandsWithStops());
+      LOG.info("Modified connectivity of {} islands with stops", stats.islandsWithStopsChanged());
       LOG.info("Removed {} edges", stats.removed());
       LOG.info("Removed traversal mode from {} edges", stats.restricted());
       LOG.info("Converted {} edges to noThruTraffic", stats.noThru());
@@ -262,15 +257,15 @@ public class IslandPruningModule implements GraphBuilderModule {
         new GraphConnectivity(
           traverseMode,
           islands.size(),
-          islandsWithStops,
-          islandsWithStopsChanged,
+          stats.islandsWithStops(),
+          stats.islandsWithStopsChanged(),
           stats.removed(),
           stats.restricted(),
           stats.noThru()
         )
       );
     }
-    return count;
+    return stats.modifiedIslands();
   }
 
   private void collectNeighbourVertices(

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruningStats.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruningStats.java
@@ -10,6 +10,9 @@ class PruningStats {
   private int removed = 0;
   private int noThru = 0;
   private int restricted = 0;
+  private int modifiedIslands = 0;
+  private int islandsWithStops = 0;
+  private int islandsWithStopsChanged = 0;
 
   void incrementIsolated() {
     isolated++;
@@ -27,6 +30,18 @@ class PruningStats {
     restricted++;
   }
 
+  void incrementModifiedIslands() {
+    modifiedIslands++;
+  }
+
+  void incrementIslandsWithStops() {
+    islandsWithStops++;
+  }
+
+  void incrementIslandsWithStopsChanged() {
+    islandsWithStopsChanged++;
+  }
+
   int isolated() {
     return isolated;
   }
@@ -41,5 +56,17 @@ class PruningStats {
 
   int restricted() {
     return restricted;
+  }
+
+  int modifiedIslands() {
+    return modifiedIslands;
+  }
+
+  int islandsWithStops() {
+    return islandsWithStops;
+  }
+
+  int islandsWithStopsChanged() {
+    return islandsWithStopsChanged;
   }
 }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruningStats.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/PruningStats.java
@@ -1,0 +1,45 @@
+package org.opentripplanner.graph_builder.module.islandpruning;
+
+/**
+ * Mutable counters tracked while {@link IslandPruningModule} processes islands and decides
+ * whether to isolate, remove, restrict or convert edges to noThruTraffic.
+ */
+class PruningStats {
+
+  private int isolated = 0;
+  private int removed = 0;
+  private int noThru = 0;
+  private int restricted = 0;
+
+  void incrementIsolated() {
+    isolated++;
+  }
+
+  void incrementRemoved() {
+    removed++;
+  }
+
+  void incrementNoThru() {
+    noThru++;
+  }
+
+  void incrementRestricted() {
+    restricted++;
+  }
+
+  int isolated() {
+    return isolated;
+  }
+
+  int removed() {
+    return removed;
+  }
+
+  int noThru() {
+    return noThru;
+  }
+
+  int restricted() {
+    return restricted;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
@@ -2,7 +2,6 @@ package org.opentripplanner.graph_builder.module.islandpruning;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -60,12 +59,12 @@ class Subgraph {
     return streetVertices.iterator().next();
   }
 
-  Iterator<Vertex> streetIterator() {
-    return streetVertices.iterator();
+  Iterable<Vertex> streetVertices() {
+    return streetVertices::iterator;
   }
 
-  Iterator<TransitStopVertex> stopIterator() {
-    return stopVertices.iterator();
+  Iterable<TransitStopVertex> stopVertices() {
+    return stopVertices::iterator;
   }
 
   // find minimal distance from a given vertex to vertices of this subgraph
@@ -143,8 +142,8 @@ class Subgraph {
 
     Consumer<Vertex> vertexAdder = vertex ->
       points.add(geometryFactory.createPoint(vertex.getCoordinate()));
-    streetIterator().forEachRemaining(vertexAdder);
-    stopIterator().forEachRemaining(vertexAdder);
+    streetVertices().forEach(vertexAdder);
+    stopVertices().forEach(vertexAdder);
 
     return new MultiPoint(points.toArray(new Point[0]), geometryFactory);
   }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
@@ -20,58 +20,58 @@ import org.opentripplanner.street.model.vertex.Vertex;
 
 class Subgraph {
 
-  private final Set<Vertex> streetVertexSet;
-  private final Set<TransitStopVertex> stopsVertexSet;
+  private final Set<Vertex> streetVertices;
+  private final Set<TransitStopVertex> stopVertices;
 
   Subgraph() {
-    streetVertexSet = new HashSet<>();
-    stopsVertexSet = new HashSet<>();
+    streetVertices = new HashSet<>();
+    stopVertices = new HashSet<>();
   }
 
   void addVertex(Vertex vertex) {
     if (vertex instanceof TransitStopVertex transitStopVertex) {
-      stopsVertexSet.add(transitStopVertex);
+      stopVertices.add(transitStopVertex);
     } else {
-      streetVertexSet.add(vertex);
+      streetVertices.add(vertex);
     }
   }
 
   boolean contains(Vertex vertex) {
-    return (streetVertexSet.contains(vertex) || stopsVertexSet.contains(vertex));
+    return (streetVertices.contains(vertex) || stopVertices.contains(vertex));
   }
 
   int streetSize() {
-    return streetVertexSet.size();
+    return streetVertices.size();
   }
 
   int stopSize() {
-    return stopsVertexSet.size();
+    return stopVertices.size();
   }
 
   Vertex getRepresentativeVertex() {
     // Return first OSM vertex if available
-    for (var vertx : streetVertexSet) {
+    for (var vertx : streetVertices) {
       if (vertx instanceof OsmVertex) {
         return vertx;
       }
     }
 
     // Otherwise fallback to what is available
-    return streetVertexSet.iterator().next();
+    return streetVertices.iterator().next();
   }
 
   Iterator<Vertex> streetIterator() {
-    return streetVertexSet.iterator();
+    return streetVertices.iterator();
   }
 
   Iterator<TransitStopVertex> stopIterator() {
-    return stopsVertexSet.iterator();
+    return stopVertices.iterator();
   }
 
   // find minimal distance from a given vertex to vertices of this subgraph
   double vertexDistanceFromSubgraph(Vertex v, double searchRadius) {
-    double d1 = computeDistance(v, searchRadius, streetVertexSet);
-    double d2 = computeDistance(v, searchRadius, stopsVertexSet);
+    double d1 = computeDistance(v, searchRadius, streetVertices);
+    double d2 = computeDistance(v, searchRadius, stopVertices);
     return Math.min(d1, d2);
   }
 
@@ -117,12 +117,11 @@ class Subgraph {
 
     Envelope envelope = new Envelope();
 
-    for (Iterator<Vertex> vIter = streetIterator(); vIter.hasNext(); ) {
-      Vertex vx = vIter.next();
-      envelope.expandToInclude(vx.getCoordinate());
+    for (var i : streetVertices) {
+      envelope.expandToInclude(i.getX(), i.getY());
     }
-    for (TransitStopVertex vx : stopsVertexSet) {
-      envelope.expandToInclude(vx.getCoordinate());
+    for (var i : stopVertices) {
+      envelope.expandToInclude(i.getX(), i.getY());
     }
     envelope.expandBy(searchRadiusDegrees / xscale, searchRadiusDegrees);
 
@@ -157,7 +156,7 @@ class Subgraph {
    * stopping at the subgraph
    */
   boolean hasOnlyFerryStops() {
-    for (TransitStopVertex v : stopsVertexSet) {
+    for (TransitStopVertex v : stopVertices) {
       if (!v.isFerryStop()) {
         return false;
       }

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
@@ -128,10 +128,10 @@ class Subgraph {
 
     return graph
       .findVertices(envelope)
-      .stream()
+      .parallelStream()
       .filter(vx -> !contains(vx))
-      .map(vx -> vertexDistanceFromSubgraph(vx, searchRadius))
-      .min(Double::compareTo)
+      .mapToDouble(vx -> vertexDistanceFromSubgraph(vx, searchRadius))
+      .min()
       .orElse(searchRadius);
   }
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
@@ -70,17 +70,40 @@ class Subgraph {
 
   // find minimal distance from a given vertex to vertices of this subgraph
   double vertexDistanceFromSubgraph(Vertex v, double searchRadius) {
-    double d1 = streetVertexSet
-      .stream()
-      .map(x -> SphericalDistanceLibrary.distance(x.getCoordinate(), v.getCoordinate()))
-      .min(Double::compareTo)
-      .orElse(searchRadius);
-    double d2 = stopsVertexSet
-      .stream()
-      .map(x -> SphericalDistanceLibrary.distance(x.getCoordinate(), v.getCoordinate()))
-      .min(Double::compareTo)
-      .orElse(searchRadius);
+    double d1 = computeDistance(v, searchRadius, streetVertexSet);
+    double d2 = computeDistance(v, searchRadius, stopsVertexSet);
     return Math.min(d1, d2);
+  }
+
+  private double computeDistance(
+    Vertex v,
+    double searchRadius,
+    Set<? extends Vertex> streetVertexSet1
+  ) {
+    double distance = Double.MAX_VALUE;
+    Vertex clostestVertex = null;
+    for (Vertex vertex : streetVertexSet1) {
+      var d = SphericalDistanceLibrary.fastDistance(
+        v.getLat(),
+        v.getLon(),
+        vertex.getLat(),
+        vertex.getLon()
+      );
+      if (d < distance) {
+        clostestVertex = vertex;
+        distance = d;
+      }
+    }
+    if (clostestVertex == null) {
+      return searchRadius;
+    } else {
+      return SphericalDistanceLibrary.distance(
+        clostestVertex.getLat(),
+        clostestVertex.getLon(),
+        v.getLat(),
+        v.getLon()
+      );
+    }
   }
 
   // Estimate distance of a subgraph from other parts of the graph.

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/islandpruning/Subgraph.java
@@ -74,14 +74,10 @@ class Subgraph {
     return Math.min(d1, d2);
   }
 
-  private double computeDistance(
-    Vertex v,
-    double searchRadius,
-    Set<? extends Vertex> streetVertexSet1
-  ) {
+  private double computeDistance(Vertex v, double searchRadius, Set<? extends Vertex> vertices) {
     double distance = Double.MAX_VALUE;
     Vertex clostestVertex = null;
-    for (Vertex vertex : streetVertexSet1) {
+    for (Vertex vertex : vertices) {
       var d = SphericalDistanceLibrary.fastDistance(
         v.getLat(),
         v.getLon(),

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/AdaptivePruningTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/AdaptivePruningTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.graph_builder.module.islandpruning.IslandPruningUtils.buildOsmGraph;
 
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.graph.Graph;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/AdaptivePruningTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/AdaptivePruningTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.graph_builder.module.islandpruning;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.graph_builder.module.islandpruning.IslandPruningUtils.buildOsmGraph;
 
@@ -47,7 +48,7 @@ class AdaptivePruningTest {
 
   @Test
   void nearIslandIsRemoved() {
-    Assertions.assertFalse(
+    assertFalse(
       graph
         .getStreetEdges()
         .stream()


### PR DESCRIPTION
### Summary

Speeds up island pruning by 20-40% (depending on the data set) by switching the nearest-vertex search to `SphericalDistanceLibrary.fastDistance`, plus some cleanup and refactoring of `IslandPruningModule`/`Subgraph`.

### Issue

Island pruning's `Subgraph#vertexDistanceFromSubgraph` used to compute the full, accurate `SphericalDistanceLibrary.distance` for every candidate vertex just to find the *nearest* one. Since only the minimum matters, most of that work is wasted precision. `Subgraph#computeDistance` now scans candidates with the much cheaper `fastDistance` (an equirectangular approximation) to find the closest vertex, and only computes the accurate `distance` once, for that single winner. The outer search over vertices in the search radius (`distanceFromOtherGraph`) was also switched from a sequential `Stream` to a primitive `parallelStream().mapToDouble(...)`, avoiding boxing and using multiple cores.

Speed-test numbers on the CI workflow for this branch show island pruning running 20-40% faster depending on the data set (the overall speed test run is roughly 1-2 minutes faster).

On top of the performance work, this PR also does some cleanup and refactoring:

- `Subgraph` field names (`streetVertexSet`/`stopsVertexSet` → `streetVertices`/`stopVertices`) and minor simplifications (envelope expansion uses `getX()`/`getY()` directly instead of allocating a `Coordinate`, iterator loops replaced with enhanced-for where possible).
- The `stats` map (`Map<String, Integer>`) that `IslandPruningModule` used for counting isolated/removed/restricted/noThru edges and island counts was replaced by a small, fully encapsulated `PruningStats` class with dedicated increment methods and getters, instead of stringly-typed map keys.

### Unit tests

- Existing `Subgraph`/`IslandPruningModule` test suites pass.
- Performance improvement verified via the performance-test GitHub Actions workflow on this branch (temporarily enabled for pushes to `island-pruning-perf`).

### Documentation

N/A — internal implementation detail, no public API or configuration changes.