### PR TITLE
Move NearbyStopFInder durationLimit and maxStopCount to Function Parameters in Preparation of Server Context Construction

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/ojp/service/CallAtStopServiceTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/ojp/service/CallAtStopServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -108,11 +109,13 @@ class CallAtStopServiceTest {
       }
 
       @Override
-      public List<NearbyStop> findNearbyStops(
+      public Collection<NearbyStop> findNearbyStops(
         Vertex vertex,
         RouteRequest routingRequest,
         StreetMode streetMode,
-        boolean reverseDirection
+        boolean reverseDirection,
+        Duration durationLimit,
+        int maxStopCount
       ) {
         return List.of();
       }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -452,7 +452,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
         MAX_SEARCH_DURATION_FOR_NEARBY_STOPS_FOR_ACCESS_EGRESS
       );
 
-      var streetNearbyStopFinder = StreetNearbyStopFinder.of(null, nearbyStopSearchDuration, 0);
+      var streetNearbyStopFinder = StreetNearbyStopFinder.of(null);
 
       // CAR_PICKUP models a walk → drive → walk chain inside a single A*. Using it here (instead
       // of plain CAR) lets the search find transit stops whose link endpoint is only walk-reachable
@@ -469,7 +469,9 @@ public class DefaultCarpoolingService implements CarpoolingService {
           Set.of(passengerSnap.vertex()),
           request,
           StreetMode.CAR_PICKUP,
-          accessOrEgress.isEgress()
+          accessOrEgress.isEgress(),
+          nearbyStopSearchDuration,
+          0
         );
       // AreaStops are GTFS Flex zones — their linked vertex is a synthetic point inside the zone,
       // not a real stop or platform a carpool driver could drop the passenger at, so skip them.

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGenerator.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGenerator.java
@@ -58,6 +58,8 @@ public class DirectTransferGenerator implements GraphBuilderModule {
   private final TransferRepository transferRepository;
   private final DataImportIssueStore issueStore;
 
+  private static final int NO_STOP_COUNT_LIMIT = 0;
+
   /**
    * Constructor used in tests. This initializes transferParametersForMode as an empty map.
    */
@@ -100,7 +102,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     transitRepository.index();
 
     // The linker will use streets if they are available, or straight-line distance otherwise.
-    NearbyStopFinder nearbyStopFinder = createNearbyStopFinder(defaultMaxTransferDuration);
+    NearbyStopFinder nearbyStopFinder = createNearbyStopFinder();
 
     List<TransitStopVertex> stops = graph.getVerticesOfType(TransitStopVertex.class);
     Set<StopLocation> carsAllowedStops =
@@ -134,7 +136,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     );
 
     // Parse the transfer configuration from the parameters given in the build config.
-    TransferConfiguration transferConfiguration = parseTransferParameters(nearbyStopFinder);
+    TransferConfiguration transferConfiguration = parseTransferParameters();
 
     var transitService = new DefaultTransitService(transitRepository);
     var emptyStops = transitRepository
@@ -170,9 +172,22 @@ public class DirectTransferGenerator implements GraphBuilderModule {
 
         LOG.debug("Linking stop '{}' {}", stop, ts0);
 
-        calculateDefaultTransfers(transferConfiguration, ts0, stop, distinctTransfers);
-        calculateFlexTransfers(transferConfiguration, ts0, stop, distinctTransfers);
+        calculateDefaultTransfers(
+          nearbyStopFinder,
+          transferConfiguration,
+          ts0,
+          stop,
+          distinctTransfers
+        );
+        calculateFlexTransfers(
+          nearbyStopFinder,
+          transferConfiguration,
+          ts0,
+          stop,
+          distinctTransfers
+        );
         calculateCarsAllowedTransfers(
+          nearbyStopFinder,
           transferConfiguration,
           ts0,
           stop,
@@ -180,6 +195,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
           carsAllowedStops
         );
         calculateBikesAllowedTransfers(
+          nearbyStopFinder,
           transferConfiguration,
           ts0,
           stop,
@@ -233,20 +249,17 @@ public class DirectTransferGenerator implements GraphBuilderModule {
    * whether the graph has a street network and if ConsiderPatternsForDirectTransfers feature is
    * enabled.
    */
-  private NearbyStopFinder createNearbyStopFinder(Duration radiusAsDuration) {
+  private NearbyStopFinder createNearbyStopFinder() {
     var transitService = new DefaultTransitService(transitRepository);
     NearbyStopFinder finder;
     if (!graph.hasStreets) {
       LOG.info(
         "Creating direct transfer edges between stops using straight line distance (not streets)..."
       );
-      finder = new StraightLineNearbyStopFinder(
-        transitService::findRegularStopsByBoundingBox,
-        radiusAsDuration
-      );
+      finder = new StraightLineNearbyStopFinder(transitService::findRegularStopsByBoundingBox);
     } else {
       LOG.info("Creating direct transfer edges between stops using the street network from OSM...");
-      finder = StreetNearbyStopFinder.of(null, radiusAsDuration, 0).build();
+      finder = StreetNearbyStopFinder.of(null).build();
     }
 
     if (OTPFeature.ConsiderPatternsForDirectTransfers.isOn()) {
@@ -280,15 +293,15 @@ public class DirectTransferGenerator implements GraphBuilderModule {
   /**
    * This method parses the given transfer parameters into a transfer configuration and checks for invalid input.
    */
-  private TransferConfiguration parseTransferParameters(NearbyStopFinder nearbyStopFinder) {
+  private TransferConfiguration parseTransferParameters() {
     List<RouteRequest> defaultTransferRequests = new ArrayList<>();
     List<RouteRequest> carsAllowedStopTransferRequests = new ArrayList<>();
     List<RouteRequest> bikesAllowedStopTransferRequests = new ArrayList<>();
     List<RouteRequest> flexTransferRequests = new ArrayList<>();
-    HashMap<StreetMode, NearbyStopFinder> defaultNearbyStopFinderForMode = new HashMap<>();
+    Map<StreetMode, Duration> defaultDurationLimitForMode = new HashMap<>();
     // These are used for calculating transfers only between carsAllowedStops.
-    HashMap<StreetMode, NearbyStopFinder> carsAllowedStopNearbyStopFinderForMode = new HashMap<>();
-    HashMap<StreetMode, NearbyStopFinder> bikesAllowedStopNearbyStopFinderForMode = new HashMap<>();
+    Map<StreetMode, Duration> carsAllowedStopDurationLimitForMode = new HashMap<>();
+    Map<StreetMode, Duration> bikesAllowedStopDurationLimitForMode = new HashMap<>();
 
     // Check that the mode specified in transferParametersForMode can also be found in transferRequests.
     for (StreetMode mode : transferParametersForMode.keySet()) {
@@ -321,9 +334,9 @@ public class DirectTransferGenerator implements GraphBuilderModule {
           // Set mode-specific maxDuration, if it is set in the build config.
           Duration maxDuration = transferParameters.maxDuration();
           if (maxDuration != null) {
-            defaultNearbyStopFinderForMode.put(mode, createNearbyStopFinder(maxDuration));
+            defaultDurationLimitForMode.put(mode, maxDuration);
           } else {
-            defaultNearbyStopFinderForMode.put(mode, nearbyStopFinder);
+            defaultDurationLimitForMode.put(mode, defaultMaxTransferDuration);
           }
         }
         // Create transfers between carsAllowedStops for the specific mode if
@@ -331,24 +344,18 @@ public class DirectTransferGenerator implements GraphBuilderModule {
         Duration carsAllowedStopMaxDuration = transferParameters.carsAllowedStopMaxDuration();
         if (carsAllowedStopMaxDuration != null) {
           carsAllowedStopTransferRequests.add(transferProfile);
-          carsAllowedStopNearbyStopFinderForMode.put(
-            mode,
-            createNearbyStopFinder(carsAllowedStopMaxDuration)
-          );
+          carsAllowedStopDurationLimitForMode.put(mode, carsAllowedStopMaxDuration);
         }
         // Create transfers between bikesAllowedStops for the specific mode if
         // bikesAllowedStopMaxDuration is set in the build config.
         Duration bikesAllowedStopMaxDuration = transferParameters.bikesAllowedStopMaxDuration();
         if (bikesAllowedStopMaxDuration != null) {
           bikesAllowedStopTransferRequests.add(transferProfile);
-          bikesAllowedStopNearbyStopFinderForMode.put(
-            mode,
-            createNearbyStopFinder(bikesAllowedStopMaxDuration)
-          );
+          bikesAllowedStopDurationLimitForMode.put(mode, bikesAllowedStopMaxDuration);
         }
       } else {
         defaultTransferRequests.add(transferProfile);
-        defaultNearbyStopFinderForMode.put(mode, nearbyStopFinder);
+        defaultDurationLimitForMode.put(mode, defaultMaxTransferDuration);
       }
     }
 
@@ -367,9 +374,9 @@ public class DirectTransferGenerator implements GraphBuilderModule {
       carsAllowedStopTransferRequests,
       bikesAllowedStopTransferRequests,
       flexTransferRequests,
-      defaultNearbyStopFinderForMode,
-      carsAllowedStopNearbyStopFinderForMode,
-      bikesAllowedStopNearbyStopFinderForMode
+      defaultDurationLimitForMode,
+      carsAllowedStopDurationLimitForMode,
+      bikesAllowedStopDurationLimitForMode
     );
   }
 
@@ -377,6 +384,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
    * This method calculates default transfers.
    */
   private void calculateDefaultTransfers(
+    NearbyStopFinder nearbyStopFinder,
     TransferConfiguration transferConfiguration,
     TransitStopVertex ts0,
     RegularStop stop,
@@ -384,10 +392,16 @@ public class DirectTransferGenerator implements GraphBuilderModule {
   ) {
     for (RouteRequest transferProfile : transferConfiguration.defaultTransferRequests()) {
       StreetMode mode = transferProfile.journey().transfer().mode();
-      var nearbyStops = transferConfiguration
-        .defaultNearbyStopFinderForMode()
-        .get(mode)
-        .findNearbyStops(ts0, transferProfile, transferProfile.journey().transfer().mode(), false);
+      Duration durationLimit = transferConfiguration.defaultDurationLimitForMode().get(mode);
+      //maxStopCount is 0 in original StreetNearbyStopFinder declaration and unused in StraightLineNearbyStopFinder
+      var nearbyStops = nearbyStopFinder.findNearbyStops(
+        ts0,
+        transferProfile,
+        mode,
+        false,
+        durationLimit,
+        NO_STOP_COUNT_LIMIT
+      );
       var repository = transitRepository.getSiteRepository();
       for (NearbyStop sd : nearbyStops) {
         // Skip the origin stop, loop transfers are not needed.
@@ -404,6 +418,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
    * This method calculates flex transfers if flex routing is enabled.
    */
   private void calculateFlexTransfers(
+    NearbyStopFinder nearbyStopFinder,
     TransferConfiguration transferConfiguration,
     TransitStopVertex ts0,
     RegularStop stop,
@@ -412,10 +427,15 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     for (RouteRequest transferProfile : transferConfiguration.flexTransferRequests()) {
       // Flex transfer requests only use the WALK mode.
       StreetMode mode = StreetMode.WALK;
-      var nearbyStops = transferConfiguration
-        .defaultNearbyStopFinderForMode()
-        .get(mode)
-        .findNearbyStops(ts0, transferProfile, transferProfile.journey().transfer().mode(), true);
+      Duration durationLimit = transferConfiguration.defaultDurationLimitForMode().get(mode);
+      var nearbyStops = nearbyStopFinder.findNearbyStops(
+        ts0,
+        transferProfile,
+        mode,
+        true,
+        durationLimit,
+        NO_STOP_COUNT_LIMIT
+      );
       // This code is for finding transfers from AreaStops to Stops, transfers
       // from Stops to AreaStops and between Stops are already covered above.
       var repository = transitRepository.getSiteRepository();
@@ -438,6 +458,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
    * This method calculates transfers between stops that are visited by trips that allow cars, if configured.
    */
   private void calculateCarsAllowedTransfers(
+    NearbyStopFinder nearbyStopFinder,
     TransferConfiguration transferConfiguration,
     TransitStopVertex ts0,
     RegularStop stop,
@@ -447,12 +468,13 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     if (carsAllowedStops.contains(stop)) {
       for (RouteRequest transferProfile : transferConfiguration.carsAllowedStopTransferRequests()) {
         calculateTransfersForStopWithAllowedStops(
+          nearbyStopFinder,
           ts0,
           stop,
           distinctTransfers,
           carsAllowedStops,
           transferProfile,
-          transferConfiguration.carsAllowedStopNearbyStopFinderForMode()
+          transferConfiguration.carsAllowedStopDurationLimitForMode
         );
       }
     }
@@ -462,6 +484,7 @@ public class DirectTransferGenerator implements GraphBuilderModule {
    * This method calculates transfers between stops that are visited by trips that allow bikes, if configured.
    */
   private void calculateBikesAllowedTransfers(
+    NearbyStopFinder nearbyStopFinder,
     TransferConfiguration transferConfiguration,
     TransitStopVertex ts0,
     RegularStop stop,
@@ -471,29 +494,37 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     if (bikesAllowedStops.contains(stop)) {
       for (RouteRequest transferProfile : transferConfiguration.bikesAllowedStopTransferRequests()) {
         calculateTransfersForStopWithAllowedStops(
+          nearbyStopFinder,
           ts0,
           stop,
           distinctTransfers,
           bikesAllowedStops,
           transferProfile,
-          transferConfiguration.bikesAllowedStopNearbyStopFinderForMode()
+          transferConfiguration.bikesAllowedStopDurationLimitForMode
         );
       }
     }
   }
 
   private void calculateTransfersForStopWithAllowedStops(
+    NearbyStopFinder nearbyStopFinder,
     TransitStopVertex ts0,
     RegularStop stop,
     Map<TransferKey, PathTransfer> distinctTransfers,
     Set<StopLocation> allowedStops,
     RouteRequest transferProfile,
-    HashMap<StreetMode, NearbyStopFinder> nearbyStopFinder
+    Map<StreetMode, Duration> durationLimitForMode
   ) {
     StreetMode mode = transferProfile.journey().transfer().mode();
-    var nearbyStops = nearbyStopFinder
-      .get(mode)
-      .findNearbyStops(ts0, transferProfile, transferProfile.journey().transfer().mode(), false);
+    Duration durationLimit = durationLimitForMode.get(mode);
+    var nearbyStops = nearbyStopFinder.findNearbyStops(
+      ts0,
+      transferProfile,
+      mode,
+      false,
+      durationLimit,
+      NO_STOP_COUNT_LIMIT
+    );
     var repository = transitRepository.getSiteRepository();
     for (NearbyStop sd : nearbyStops) {
       var nearbyStop = repository.getStopLocation(sd.stopId);
@@ -517,9 +548,9 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     List<RouteRequest> carsAllowedStopTransferRequests,
     List<RouteRequest> bikesAllowedStopTransferRequests,
     List<RouteRequest> flexTransferRequests,
-    HashMap<StreetMode, NearbyStopFinder> defaultNearbyStopFinderForMode,
-    HashMap<StreetMode, NearbyStopFinder> carsAllowedStopNearbyStopFinderForMode,
-    HashMap<StreetMode, NearbyStopFinder> bikesAllowedStopNearbyStopFinderForMode
+    Map<StreetMode, Duration> defaultDurationLimitForMode,
+    Map<StreetMode, Duration> carsAllowedStopDurationLimitForMode,
+    Map<StreetMode, Duration> bikesAllowedStopDurationLimitForMode
   ) {}
 
   private record TransferKey(StopLocation source, StopLocation target, List<Edge> edges) {}

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGenerator.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/transfer/DirectTransferGenerator.java
@@ -393,7 +393,6 @@ public class DirectTransferGenerator implements GraphBuilderModule {
     for (RouteRequest transferProfile : transferConfiguration.defaultTransferRequests()) {
       StreetMode mode = transferProfile.journey().transfer().mode();
       Duration durationLimit = transferConfiguration.defaultDurationLimitForMode().get(mode);
-      //maxStopCount is 0 in original StreetNearbyStopFinder declaration and unused in StraightLineNearbyStopFinder
       var nearbyStops = nearbyStopFinder.findNearbyStops(
         ts0,
         transferProfile,

--- a/application/src/main/java/org/opentripplanner/place/NearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/NearbyStopFinder.java
@@ -17,8 +17,7 @@ public interface NearbyStopFinder {
   /**
    * Return all stops within a certain distance from the given vertex.
    *
-   * @param maxStopCount The maximum stops to return. 0 means no limit. Regardless of the maxStopCount
-   * we will always return all the directly connected stops.
+   * @param maxStopCount The maximum stops to return. 0 means no limit.
    */
   Collection<NearbyStop> findNearbyStops(
     Vertex vertex,

--- a/application/src/main/java/org/opentripplanner/place/NearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/NearbyStopFinder.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.place;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import org.locationtech.jts.geom.Coordinate;
@@ -15,12 +16,17 @@ import org.opentripplanner.street.model.vertex.Vertex;
 public interface NearbyStopFinder {
   /**
    * Return all stops within a certain distance from the given vertex.
+   *
+   * @param maxStopCount The maximum stops to return. 0 means no limit. Regardless of the maxStopCount
+   * we will always return all the directly connected stops.
    */
   Collection<NearbyStop> findNearbyStops(
     Vertex vertex,
     RouteRequest routingRequest,
     StreetMode streetMode,
-    boolean reverseDirection
+    boolean reverseDirection,
+    Duration durationLimit,
+    int maxStopCount
   );
 
   /**

--- a/application/src/main/java/org/opentripplanner/place/nearbystopfinder/PatternConsideringNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/nearbystopfinder/PatternConsideringNearbyStopFinder.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.place.nearbystopfinder;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import org.locationtech.jts.geom.Coordinate;
@@ -61,7 +62,9 @@ public class PatternConsideringNearbyStopFinder implements NearbyStopFinder {
     Vertex vertex,
     RouteRequest routingRequest,
     StreetMode streetMode,
-    boolean reverseDirection
+    boolean reverseDirection,
+    Duration durationLimit,
+    int maxStopCount
   ) {
     if (!(vertex instanceof TransitStopVertex stopVertex)) {
       throw new IllegalArgumentException(
@@ -79,7 +82,9 @@ public class PatternConsideringNearbyStopFinder implements NearbyStopFinder {
       vertex,
       routingRequest,
       streetMode,
-      reverseDirection
+      reverseDirection,
+      durationLimit,
+      maxStopCount
     );
 
     // Remove transfersNotAllowed stops BEFORE we filter in Pattern and Flex Trips

--- a/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StraightLineNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StraightLineNearbyStopFinder.java
@@ -18,22 +18,12 @@ import org.opentripplanner.transit.model.site.RegularStop;
 
 public class StraightLineNearbyStopFinder implements NearbyStopFinder {
 
-  private final Duration durationLimit;
   private final Function<Envelope, Collection<RegularStop>> queryNearbyStops;
 
   public StraightLineNearbyStopFinder(
     Function<Envelope, Collection<RegularStop>> queryNearbyStops
   ) {
-    this(queryNearbyStops, Duration.ofHours(10000));
-  }
-
-  public StraightLineNearbyStopFinder(
-    Function<Envelope, Collection<RegularStop>> queryNearbyStops,
-    Duration durationLimit
-  ) {
     this.queryNearbyStops = queryNearbyStops;
-    // TODO move request specific parameters to method
-    this.durationLimit = durationLimit;
   }
 
   /**
@@ -71,12 +61,17 @@ public class StraightLineNearbyStopFinder implements NearbyStopFinder {
     Vertex vertex,
     RouteRequest routingRequest,
     StreetMode streetMode,
-    boolean reverseDirection
+    boolean reverseDirection,
+    Duration durationLimit,
+    int maxStopCount
   ) {
-    return findNearbyStopsViaDirectTransfers(vertex);
+    return findNearbyStopsViaDirectTransfers(vertex, durationLimit);
   }
 
-  private List<NearbyStop> findNearbyStopsViaDirectTransfers(Vertex vertex) {
+  private List<NearbyStop> findNearbyStopsViaDirectTransfers(
+    Vertex vertex,
+    Duration durationLimit
+  ) {
     // TODO why we use default speed here?
     double limitMeters = durationLimit.toSeconds() * WalkPreferences.DEFAULT.speed();
     Coordinate c0 = vertex.getCoordinate();

--- a/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StraightLineNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StraightLineNearbyStopFinder.java
@@ -65,16 +65,23 @@ public class StraightLineNearbyStopFinder implements NearbyStopFinder {
     Duration durationLimit,
     int maxStopCount
   ) {
-    return findNearbyStopsViaDirectTransfers(vertex, durationLimit);
+    return findNearbyStopsViaDirectTransfers(vertex, durationLimit, maxStopCount);
   }
 
   private List<NearbyStop> findNearbyStopsViaDirectTransfers(
     Vertex vertex,
-    Duration durationLimit
+    Duration durationLimit,
+    int maxStopCount
   ) {
     // TODO why we use default speed here?
     double limitMeters = durationLimit.toSeconds() * WalkPreferences.DEFAULT.speed();
     Coordinate c0 = vertex.getCoordinate();
-    return findNearbyStops(c0, limitMeters);
+    List<NearbyStop> stopsFound = findNearbyStops(c0, limitMeters);
+
+    if (maxStopCount > 0 && stopsFound.size() > maxStopCount) {
+      return List.copyOf(stopsFound.subList(0, maxStopCount));
+    }
+
+    return stopsFound;
   }
 }

--- a/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinder.java
@@ -38,51 +38,28 @@ import org.opentripplanner.streetadapter.StreetSearchRequestMapper;
 public class StreetNearbyStopFinder implements NearbyStopFinder {
 
   private final LinkingContextFactory linkingContextFactory;
-  private final Duration durationLimit;
-  private final int maxStopCount;
   private final Collection<ExtensionRequestContext> extensionRequestContexts;
   private final Set<Vertex> ignoreVertices;
 
   /**
    * Construct a NearbyStopFinder for the given graph and search radius.
    *
-   * @param maxStopCount The maximum stops to return. 0 means no limit. Regardless of the maxStopCount
-   *                     we will always return all the directly connected stops.
    * @param ignoreVertices   A set of stop vertices to ignore and not return NearbyStops for.
    */
   private StreetNearbyStopFinder(
     @Nullable LinkingContextFactory linkingContextFactory,
-    Duration durationLimit,
-    int maxStopCount,
     Collection<ExtensionRequestContext> extensionRequestContexts,
     Set<Vertex> ignoreVertices
   ) {
     // This is temporarily nullable as we don't need it when we don't link coordinates, but soon
     // setting this everywhere will be easier once construction is moved to dagger
     this.linkingContextFactory = linkingContextFactory;
-    // TODO move request specific parameters to method
-    this.durationLimit = requireNonNull(durationLimit);
-    this.maxStopCount = requireNonNull(maxStopCount);
     this.extensionRequestContexts = requireNonNull(extensionRequestContexts);
     this.ignoreVertices = requireNonNull(ignoreVertices);
   }
 
   public static Builder of(LinkingContextFactory linkingContextFactory) {
     return new Builder(linkingContextFactory);
-  }
-
-  /**
-   * Build a NearbyStopFinder for the given graph and search radius, defined by the
-   * {@code durationLimit}.
-   * @param maxStopCount The maximum stops to return. 0 means no limit. Regardless of the
-   *                     maxStopCount we will always return all the directly connected stops.
-   */
-  public static Builder of(
-    LinkingContextFactory linkingContextFactory,
-    Duration durationLimit,
-    int maxStopCount
-  ) {
-    return new Builder(linkingContextFactory, durationLimit, maxStopCount);
   }
 
   @Override
@@ -107,9 +84,18 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
     Vertex vertex,
     RouteRequest routingRequest,
     StreetMode streetMode,
-    boolean reverseDirection
+    boolean reverseDirection,
+    Duration durationLimit,
+    int maxStopCount
   ) {
-    return findNearbyStops(Set.of(vertex), routingRequest, streetMode, reverseDirection);
+    return findNearbyStops(
+      Set.of(vertex),
+      routingRequest,
+      streetMode,
+      reverseDirection,
+      durationLimit,
+      maxStopCount
+    );
   }
 
   /**
@@ -160,7 +146,9 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
     Set<Vertex> originVertices,
     RouteRequest request,
     StreetMode streetMode,
-    boolean reverseDirection
+    boolean reverseDirection,
+    Duration durationLimit,
+    int maxStopCount
   ) {
     OTPRequestTimeoutException.checkForTimeout();
 
@@ -247,24 +235,11 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
   public static class Builder {
 
     private final LinkingContextFactory linkingContextFactory;
-    // TODO these should be moved to be method parameters instead of constructor
-    private Duration durationLimit = Duration.ofHours(10000);
-    private int maxStopCount = 1000;
     private Collection<ExtensionRequestContext> extensionRequestContexts = List.of();
     private Set<Vertex> ignoreVertices = Set.of();
 
     public Builder(LinkingContextFactory linkingContextFactory) {
       this.linkingContextFactory = linkingContextFactory;
-    }
-
-    public Builder(
-      LinkingContextFactory linkingContextFactory,
-      Duration durationLimit,
-      int maxStopCount
-    ) {
-      this.linkingContextFactory = linkingContextFactory;
-      this.durationLimit = durationLimit;
-      this.maxStopCount = maxStopCount;
     }
 
     /**
@@ -291,8 +266,6 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
     public StreetNearbyStopFinder build() {
       return new StreetNearbyStopFinder(
         linkingContextFactory,
-        durationLimit,
-        maxStopCount,
         extensionRequestContexts,
         ignoreVertices
       );

--- a/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinder.java
+++ b/application/src/main/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinder.java
@@ -141,6 +141,8 @@ public class StreetNearbyStopFinder implements NearbyStopFinder {
    * @param originVertices   the origin point of the street search.
    * @param reverseDirection if true the paths returned instead originate at the nearby stops and
    *                         have the originVertex as the destination.
+   * @param maxStopCount The maximum stops to return. 0 means no limit. Regardless of the maxStopCount
+   *                         we will always return all the directly connected stops.
    */
   public Collection<NearbyStop> findNearbyStops(
     Set<Vertex> originVertices,

--- a/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
+++ b/application/src/main/java/org/opentripplanner/routing/algorithm/raptoradapter/router/street/AccessEgressRouter.java
@@ -56,11 +56,18 @@ public class AccessEgressRouter {
     var originVertices = accessOrEgress.isAccess()
       ? linkingContext.findVertices(request.from())
       : linkingContext.findVertices(request.to());
-    var streetAccessEgress = StreetNearbyStopFinder.of(null, durationLimit, maxStopCount)
+    var streetAccessEgress = StreetNearbyStopFinder.of(null)
       .withIgnoreVertices(ignoreVertices)
       .withExtensionRequestContexts(extensionRequestContexts)
       .build()
-      .findNearbyStops(originVertices, request, streetMode, accessOrEgress.isEgress());
+      .findNearbyStops(
+        originVertices,
+        request,
+        streetMode,
+        accessOrEgress.isEgress(),
+        durationLimit,
+        maxStopCount
+      );
 
     var results = ListUtils.combine(zeroDistanceAccessEgress, streetAccessEgress);
     LOG.debug("Found {} {} stops", results.size(), accessOrEgress);

--- a/application/src/main/java/org/opentripplanner/routing/via/service/DefaultViaCoordinateTransferFactory.java
+++ b/application/src/main/java/org/opentripplanner/routing/via/service/DefaultViaCoordinateTransferFactory.java
@@ -44,7 +44,7 @@ public class DefaultViaCoordinateTransferFactory implements ViaCoordinateTransfe
     Vertex location,
     WgsCoordinate coordinate
   ) {
-    var nearbyStopFinder = createNearbyStopFinder(radiusAsDuration);
+    var nearbyStopFinder = createNearbyStopFinder();
 
     var toStops = findNearbyStops(nearbyStopFinder, location, request, false);
     var fromStops = findNearbyStops(nearbyStopFinder, location, request, true);
@@ -73,14 +73,11 @@ public class DefaultViaCoordinateTransferFactory implements ViaCoordinateTransfe
    * Factory method for creating a NearbyStopFinder. The linker will use streets if they are
    * available, or straight-line distance otherwise.
    */
-  private NearbyStopFinder createNearbyStopFinder(Duration radiusAsDuration) {
+  private NearbyStopFinder createNearbyStopFinder() {
     if (!graph.hasStreets) {
-      return new StraightLineNearbyStopFinder(
-        transitService::findRegularStopsByBoundingBox,
-        radiusAsDuration
-      );
+      return new StraightLineNearbyStopFinder(transitService::findRegularStopsByBoundingBox);
     } else {
-      return StreetNearbyStopFinder.of(null, radiusAsDuration, 0).build();
+      return StreetNearbyStopFinder.of(null).build();
     }
   }
 
@@ -94,7 +91,14 @@ public class DefaultViaCoordinateTransferFactory implements ViaCoordinateTransfe
     boolean reverseDirection
   ) {
     var transferMode = request.journey().transfer().mode();
-    var r = finder.findNearbyStops(viaVertex, request, transferMode, reverseDirection);
+    var r = finder.findNearbyStops(
+      viaVertex,
+      request,
+      transferMode,
+      reverseDirection,
+      radiusAsDuration,
+      0
+    );
     return r
       .stream()
       .filter(it -> !transitService.getStopLocation(it.stopId).transfersNotAllowed())

--- a/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StraightLineNearbyStopFinderTest.java
+++ b/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StraightLineNearbyStopFinderTest.java
@@ -2,6 +2,7 @@ package org.opentripplanner.place.nearbystopfinder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,8 @@ import org.locationtech.jts.geom.Coordinate;
 import org.opentripplanner.TestOtpModel;
 import org.opentripplanner.place.api.NearbyStop;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.routing.api.request.RouteRequest;
+import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.vertex.TransitStopVertex;
 import org.opentripplanner.transit.service.SiteRepository;
 
@@ -45,5 +48,33 @@ class StraightLineNearbyStopFinderTest extends GraphRoutingTest {
     assertEquals(List.of(ns1), subject.findNearbyStops(coordinate, 100));
 
     assertEquals(List.of(ns1, ns2), subject.findNearbyStops(coordinate, 2000));
+  }
+
+  @Test
+  void findNearbyStopsWithMaxStopCount() {
+    var ns1 = new NearbyStop(S1.getId(), 0, null, null);
+    var ns2 = new NearbyStop(S2.getId(), 1112, null, null);
+
+    var subject = new StraightLineNearbyStopFinder(siteRepository::findRegularStops);
+
+    var limitedStops = subject.findNearbyStops(
+      S1,
+      RouteRequest.defaultValue(),
+      StreetMode.WALK,
+      false,
+      Duration.ofSeconds(3000),
+      2
+    );
+    assertEquals(List.of(ns1, ns2), limitedStops);
+
+    var unlimitedStops = subject.findNearbyStops(
+      S1,
+      RouteRequest.defaultValue(),
+      StreetMode.WALK,
+      false,
+      Duration.ofSeconds(3000),
+      0
+    );
+    assertEquals(3, unlimitedStops.size());
   }
 }

--- a/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinderMultipleLinksTest.java
+++ b/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinderMultipleLinksTest.java
@@ -61,10 +61,17 @@ class StreetNearbyStopFinderMultipleLinksTest extends GraphRoutingTest {
     // Max-stop-count should work correctly even though there are multiple links B <-> stopB
     var durationLimit = Duration.ofMinutes(10);
     var maxStopCount = 3;
-    var finder = StreetNearbyStopFinder.of(null, durationLimit, maxStopCount).build();
+    var finder = StreetNearbyStopFinder.of(null).build();
 
     var sortedNearbyStops = sort(
-      finder.findNearbyStops(stopA, RouteRequest.defaultValue(), StreetMode.WALK, false)
+      finder.findNearbyStops(
+        stopA,
+        RouteRequest.defaultValue(),
+        StreetMode.WALK,
+        false,
+        durationLimit,
+        maxStopCount
+      )
     );
 
     assertThat(sortedNearbyStops).hasSize(3);

--- a/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinderTest.java
+++ b/application/src/test/java/org/opentripplanner/place/nearbystopfinder/StreetNearbyStopFinderTest.java
@@ -90,17 +90,15 @@ class StreetNearbyStopFinderTest extends GraphRoutingTest {
   void testIsolatedStop() {
     var durationLimit = Duration.ofMinutes(10);
     var maxStopCount = 0;
-    var finder = StreetNearbyStopFinder.of(
-      linkingContextFactory,
-      durationLimit,
-      maxStopCount
-    ).build();
+    var finder = StreetNearbyStopFinder.of(linkingContextFactory).build();
 
     var nearbyStops = finder.findNearbyStops(
       isolatedStop,
       RouteRequest.defaultValue(),
       StreetMode.WALK,
-      false
+      false,
+      durationLimit,
+      maxStopCount
     );
 
     assertThat(nearbyStops).hasSize(1);
@@ -112,14 +110,17 @@ class StreetNearbyStopFinderTest extends GraphRoutingTest {
   void testMultipleStops() {
     var durationLimit = Duration.ofMinutes(10);
     var maxStopCount = 0;
-    var finder = StreetNearbyStopFinder.of(
-      linkingContextFactory,
-      durationLimit,
-      maxStopCount
-    ).build();
+    var finder = StreetNearbyStopFinder.of(linkingContextFactory).build();
 
     var sortedNearbyStops = sort(
-      finder.findNearbyStops(stopA, RouteRequest.defaultValue(), StreetMode.WALK, false)
+      finder.findNearbyStops(
+        stopA,
+        RouteRequest.defaultValue(),
+        StreetMode.WALK,
+        false,
+        durationLimit,
+        maxStopCount
+      )
     );
 
     assertThat(sortedNearbyStops).hasSize(4);
@@ -133,14 +134,17 @@ class StreetNearbyStopFinderTest extends GraphRoutingTest {
   void testMaxStopCount() {
     var durationLimit = Duration.ofMinutes(10);
     var maxStopCount = 2;
-    var finder = StreetNearbyStopFinder.of(
-      linkingContextFactory,
-      durationLimit,
-      maxStopCount
-    ).build();
+    var finder = StreetNearbyStopFinder.of(linkingContextFactory).build();
 
     var sortedNearbyStops = sort(
-      finder.findNearbyStops(stopA, RouteRequest.defaultValue(), StreetMode.WALK, false)
+      finder.findNearbyStops(
+        stopA,
+        RouteRequest.defaultValue(),
+        StreetMode.WALK,
+        false,
+        durationLimit,
+        maxStopCount
+      )
     );
 
     assertThat(sortedNearbyStops).hasSize(2);
@@ -158,13 +162,16 @@ class StreetNearbyStopFinderTest extends GraphRoutingTest {
       .withPreferences(b -> b.withWalk(w -> w.withSpeed(1.0)))
       .buildDefault();
 
-    var finder = StreetNearbyStopFinder.of(
-      linkingContextFactory,
-      durationLimit,
-      maxStopCount
-    ).build();
+    var finder = StreetNearbyStopFinder.of(linkingContextFactory).build();
     var sortedNearbyStops = sort(
-      finder.findNearbyStops(stopA, routeRequest, StreetMode.WALK, false)
+      finder.findNearbyStops(
+        stopA,
+        routeRequest,
+        StreetMode.WALK,
+        false,
+        durationLimit,
+        maxStopCount
+      )
     );
 
     assertThat(sortedNearbyStops).hasSize(2);
@@ -177,12 +184,19 @@ class StreetNearbyStopFinderTest extends GraphRoutingTest {
     var durationLimit = Duration.ofMinutes(10);
     var maxStopCount = 0;
     Set<Vertex> ignore = Set.of(stopA, stopB);
-    var finder = StreetNearbyStopFinder.of(linkingContextFactory, durationLimit, maxStopCount)
+    var finder = StreetNearbyStopFinder.of(linkingContextFactory)
       .withIgnoreVertices(ignore)
       .build();
 
     var sortedNearbyStops = sort(
-      finder.findNearbyStops(Set.of(stopA), RouteRequest.defaultValue(), StreetMode.WALK, false)
+      finder.findNearbyStops(
+        Set.of(stopA),
+        RouteRequest.defaultValue(),
+        StreetMode.WALK,
+        false,
+        durationLimit,
+        maxStopCount
+      )
     );
 
     assertThat(sortedNearbyStops).hasSize(2);
@@ -195,12 +209,19 @@ class StreetNearbyStopFinderTest extends GraphRoutingTest {
     var durationLimit = Duration.ofMinutes(10);
     var maxStopCount = 1;
     Set<Vertex> ignore = Set.of(stopA, stopB);
-    var finder = StreetNearbyStopFinder.of(linkingContextFactory, durationLimit, maxStopCount)
+    var finder = StreetNearbyStopFinder.of(linkingContextFactory)
       .withIgnoreVertices(ignore)
       .build();
 
     var sortedNearbyStops = sort(
-      finder.findNearbyStops(Set.of(stopA), RouteRequest.defaultValue(), StreetMode.WALK, false)
+      finder.findNearbyStops(
+        Set.of(stopA),
+        RouteRequest.defaultValue(),
+        StreetMode.WALK,
+        false,
+        durationLimit,
+        maxStopCount
+      )
     );
 
     assertThat(sortedNearbyStops).hasSize(1);


### PR DESCRIPTION
### Summary

This PR refactors the NearbyStopFinder implementations to move `durationLimit` and `maxStopCount` from their constructors/builders to their vertex-based `findNearbyStops` method. This work is in preparation of having a more generic way to generate transfers by moving the NearbyStopFinder's construction to server context. 

### Issue

Resolves the `TODO move request specific parameters to method` comments introduced in #7565.



 Interface: `findNearbyStops(Vertex, RouteRequest, StreetMode, boolean)` gains `Duration
  durationLimit, int maxStopCount`. The coordinate-based overload already takes its limit
  (`radiusMeters`) per call and is unchanged.
- `StreetNearbyStopFinder`: the two limit fields are removed; the three-argument `of(...)` factory
  and matching Builder constructor are deleted. `StraightLineNearbyStopFinder`: the two-argument
  constructor is deleted; `maxStopCount` remains unused there, as before.
  `PatternConsideringNearbyStopFinder` passes both parameters through to its delegate.
- `StraightLineNearbyStopFinder`: Per review feedback, this now supports maxStopCount by truncating its distance-sorted result (0 still means no limit). Note that no current caller passes a non-zero count to it.
- Call sites updated to pass the same values they previously passed at construction:
  `AccessEgressRouter` (per-request preference values), `DirectTransferGenerator` (build-config
  durations, stop count 0 = no limit), `DefaultViaCoordinateTransferFactory`, and the carpooling
  sandbox service. No behavior change: every search runs with the same limits as before.
- `DirectTransferGenerator` previously needed one finder instance per distinct duration and kept
  three `Map<StreetMode, NearbyStopFinder>` maps for that purpose; these become one shared finder
  plus three `Map<StreetMode, Duration>`. This is the minimal translation of the
  constructor-to-method move, not a redesign. `DirectTransferGenerator` contains the bulk of the refactoring work to support this change. 

### Unit tests

Add 1 new unit test "findNearbyStopsWithMaxStopCount" for StraightLineNearbyStopFinderTest to ensure both specified and value 0 maxStopCount worked as entailed. No observable changes performance

Unit tests were also updated to pass in `durationLimit` and `maxStopCount`. 

`mvn clean package` command was ran and a local `graph.obj` was built and loaded successfully with the same before and after build output from the `DirectTransferGenreator` class. Routes were successfully created in the debug console UI.