### PR TITLE
Mention Iterable in naming convention

### DIFF
--- a/doc/dev/decisionrecords/NamingConventions.md
+++ b/doc/dev/decisionrecords/NamingConventions.md
@@ -36,24 +36,24 @@ be `org.opentripplanner.<domain>.<component>.<sub-component>`.
 
 Here is a list of common prefixes used and what to expect.
 
-| Good method prefixes                                  | Description                                                                                                |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `stop() : Stop`                                       | Field accessor, equivalent to `getStop` as in the Java Bean standard.                                      |
-| `getStop(ID id) : Stop`                               | Get Stop by ID; throws exception if not found.                                                             |
-| `getStops(Collection<ID> id) : List/Collection<Stop>` | Get _all_ Stops by set of IDs; throws exception if not found.                                              |
-| `findStop(Criteria criteria) : Optional<Stop>`        | Find one or zero stops; return `Optional`.                                                                 |
-| `findStops(Criteria criteria) : List/Stream<Stop>`    | Find 0, 1, or many stops; return a Collection or Stream (List is preferred).                               |
-| `listStops() : List/Stream<Stop>`                     | List ALL stops in context; return a Collection or Stream (List is preferred).                              |
-| `initStop(Stop stop) : void`                          | Set property _once_; a second call throws an exception.                                                    |
-| `createStop(String name, ...) : Stop`                 | Factory methods for creating objects should start with `create` prefix.                                    |
-|                                                       | See (Builder Conventions)[RecordsPOJOsBuilders.md#builder-conventions] for creating objects with builders. |
-| `addStop(Stop stop) : void/Builder`                   | Add a Stop to a collection of Stops.                                                                       |
-| `addStops(Collection<Stop> stops) : void/Builder`     | Add set of Stops to existing set.                                                                          |
-| `withBike(Consumer<BikePref.Builder> body) : Builder` | For nested builders, use lambdas.                                                                          |
-| `withStop(Stop stop) : Builder`                       | Set Stop in builder, replacing existing value; return `this` builder.                                      |
-| `of(FeedScopedId id) : Builder`                       | Create new builder instance from `Stop` class.                                                             |
-| `copyOf() : Builder`                                  | Initialize a new builder instance from `Stop` instance with identical values.                              |
-| `build() : Stop`                                      | Finish building stop with a builder.                                                                       |
+| Good method prefixes                                              | Description                                                                                                |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `stop() : Stop`                                                   | Field accessor, equivalent to `getStop` as in the Java Bean standard.                                      |
+| `getStop(ID id) : Stop`                                           | Get Stop by ID; throws exception if not found.                                                             |
+| `getStops(Collection<ID> id) : Collection/Iterable/Stream<Stop>`  | Get _all_ Stops by set of IDs; throws exception if not found.                                              |
+| `findStop(Criteria criteria) : Optional<Stop>`                    | Find one or zero stops; return `Optional`.                                                                 |
+| `findStops(Criteria criteria) : Collection/Iterable/Stream<Stop>` | Find 0, 1, or many stops; return a Collection, Iterable or Stream (List is preferred).                     |
+| `listStops() : Collection/Iterable/Stream<Stop>`                  | List ALL stops in context; return a Collection, Iterable or Stream (List is preferred).                    |
+| `initStop(Stop stop) : void`                                      | Set property _once_; a second call throws an exception.                                                    |
+| `createStop(String name, ...) : Stop`                             | Factory methods for creating objects should start with `create` prefix.                                    |
+|                                                                   | See (Builder Conventions)[RecordsPOJOsBuilders.md#builder-conventions] for creating objects with builders. |
+| `addStop(Stop stop) : void/Builder`                               | Add a Stop to a collection of Stops.                                                                       |
+| `addStops(Collection<Stop> stops) : void/Builder`                 | Add set of Stops to existing set.                                                                          |
+| `withBike(Consumer<BikePref.Builder> body) : Builder`             | For nested builders, use lambdas.                                                                          |
+| `withStop(Stop stop) : Builder`                                   | Set Stop in builder, replacing existing value; return `this` builder.                                      |
+| `of(FeedScopedId id) : Builder`                                   | Create new builder instance from `Stop` class.                                                             |
+| `copyOf() : Builder`                                              | Initialize a new builder instance from `Stop` instance with identical values.                              |
+| `build() : Stop`                                                  | Finish building stop with a builder.                                                                       |
 
 These prefixes are also "allowed" but not preferred; they have some kind of negative "force" to
 them.


### PR DESCRIPTION
In today's meeting we decided that the findXXX/listXXX naming convention also applies to iterables.