### PR TITLE
Honour request cancellation in carpooling street searches

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouterTest.java
@@ -1,0 +1,83 @@
+package org.opentripplanner.ext.carpooling.routing;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
+import org.opentripplanner.routing.algorithm.GraphRoutingTest;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.model.vertex.IntersectionVertex;
+import org.opentripplanner.street.service.StreetLimitationParametersService;
+
+class CarpoolStreetRouterTest extends GraphRoutingTest {
+
+  private static final WgsCoordinate ORIGIN = new WgsCoordinate(59.9139, 10.7522);
+
+  private static final CarpoolStreetRouter ROUTER = new CarpoolStreetRouter(
+    StreetLimitationParametersService.DEFAULT
+  );
+
+  private IntersectionVertex vertexA;
+  private IntersectionVertex vertexC;
+  private IntersectionVertex vertexDisconnected;
+
+  @BeforeEach
+  void setUp() {
+    modelOf(
+      new Builder() {
+        @Override
+        public void build() {
+          var A = intersection("A", ORIGIN);
+          var B = intersection("B", ORIGIN.moveEastMeters(500));
+          var C = intersection("C", ORIGIN.moveEastMeters(1000));
+          var Z = intersection("Z", ORIGIN.moveNorthMeters(500));
+
+          biStreet(A, B, 500);
+          biStreet(B, C, 500);
+          // Z has no edges — disconnected from the rest of the graph
+
+          vertexA = A;
+          vertexC = C;
+          vertexDisconnected = Z;
+        }
+      }
+    );
+  }
+
+  /**
+   * Clears the interrupt flag so that a cancellation raised by one test cannot surface as a
+   * spurious {@link OTPRequestTimeoutException} in an unrelated test sharing the same thread.
+   */
+  @AfterEach
+  void clearInterruptFlag() {
+    Thread.interrupted();
+  }
+
+  @Test
+  void routeBetweenConnectedVertices() {
+    assertThat(ROUTER.route(vertexA, vertexC)).isNotNull();
+  }
+
+  @Test
+  void returnNullWhenNoPathExists() {
+    assertThat(ROUTER.route(vertexA, vertexDisconnected)).isNull();
+  }
+
+  /**
+   * A cancelled search has no verdict on whether the leg is routable, so it must not be reported as
+   * a routing failure: the caller memoizes a null return as "unroutable" for every later request.
+   * The router carries no state between calls, so the pair routes for real once the cancellation
+   * is over.
+   */
+  @Test
+  void propagateCancellationInsteadOfReturningNull() {
+    Thread.currentThread().interrupt();
+    assertThrows(OTPRequestTimeoutException.class, () -> ROUTER.route(vertexA, vertexC));
+    Thread.interrupted();
+
+    assertThat(ROUTER.route(vertexA, vertexC)).isNotNull();
+  }
+}

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouterTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouterTest.java
@@ -5,12 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.TestOtpModel;
 import org.opentripplanner.ext.carpooling.util.StreetVertexUtils;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
 import org.opentripplanner.routing.linking.internal.VertexCreationService;
@@ -60,6 +63,15 @@ class CarpoolTreeStreetRouterTest extends GraphRoutingTest {
     );
 
     router = new CarpoolTreeStreetRouter();
+  }
+
+  /**
+   * Clears the interrupt flag so that a cancellation raised by one test cannot surface as a
+   * spurious {@link OTPRequestTimeoutException} in an unrelated test sharing the same thread.
+   */
+  @AfterEach
+  void clearInterruptFlag() {
+    Thread.interrupted();
   }
 
   @Test
@@ -183,6 +195,30 @@ class CarpoolTreeStreetRouterTest extends GraphRoutingTest {
 
     var path = router.route(vertexA, vertexDisconnected);
     assertNull(path, "Should return null for unreachable vertex in the same graph");
+  }
+
+  /**
+   * The tree is built inside {@code route}, so a cancelled request surfaces there. A cancellation
+   * carries no verdict on whether the leg is routable: it must be raised as an exception rather
+   * than reported as a missing path, and it must leave nothing behind that would answer a later
+   * query for the same pair. A missing path is memoized — the pair is put in the path cache as
+   * {@code null} and every later query for it is answered from the cache without rebuilding the
+   * tree — so a cancelled call that entered that cache would make the pair permanently unroutable.
+   * The tree registration must survive for the same reason: consuming it leaves no tree to route
+   * the pair with.
+   */
+  @Test
+  void propagateCancellationInsteadOfReturningNull() {
+    router.addVertex(vertexA, CarpoolTreeStreetRouter.Direction.FROM, SEARCH_LIMIT);
+
+    Thread.currentThread().interrupt();
+    assertThrows(OTPRequestTimeoutException.class, () -> router.route(vertexA, vertexC));
+    Thread.interrupted();
+
+    assertNotNull(
+      router.route(vertexA, vertexC),
+      "A cancelled call must leave behind neither a cached null nor a consumed registration"
+    );
   }
 
   @Test

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/CarReachableVertexSnapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/CarReachableVertexSnapperTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.street.model.edge.TemporaryFreeEdge.createTemporaryFreeEdge;
 
 import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.routing.algorithm.GraphRoutingTest;
 import org.opentripplanner.routing.linking.VertexLinkerTestFactory;
 import org.opentripplanner.routing.linking.internal.VertexCreationService;
@@ -68,6 +71,34 @@ class CarReachableVertexSnapperTest extends GraphRoutingTest {
         }
       }
     );
+  }
+
+  /**
+   * Clears the interrupt flag so that a cancellation raised by one test cannot surface as a
+   * spurious {@link OTPRequestTimeoutException} in an unrelated test sharing the same thread.
+   */
+  @AfterEach
+  void clearInterruptFlag() {
+    Thread.interrupted();
+  }
+
+  /**
+   * The walk search runs inside the snap, so a cancelled request surfaces there. A cancellation
+   * carries no verdict on whether a car-reachable vertex is within the walk budget: it must be
+   * raised as an exception rather than reported as a missing snap, and it must leave no verdict
+   * behind that a later snap of the same vertex would read.
+   */
+  @Test
+  void propagateCancellationInsteadOfReturningNull() {
+    Thread.currentThread().interrupt();
+    assertThrows(OTPRequestTimeoutException.class, () ->
+      snapper.snapPickup(StreetSearchRequest.DEFAULT, A, Duration.ofMinutes(10))
+    );
+    Thread.interrupted();
+
+    var result = snapper.snapPickup(StreetSearchRequest.DEFAULT, A, Duration.ofMinutes(10));
+    assertNotNull(result, "A cancelled snap must leave no verdict behind");
+    assertEquals(C, result.vertex());
   }
 
   @Test

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolRouter.java
@@ -1,6 +1,8 @@
 package org.opentripplanner.ext.carpooling.routing;
 
+import javax.annotation.Nullable;
 import org.opentripplanner.astar.model.GraphPath;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.search.state.State;
@@ -10,5 +12,15 @@ import org.opentripplanner.street.search.state.State;
  */
 @FunctionalInterface
 public interface CarpoolRouter {
+  /**
+   * Routes in CAR mode from {@code from} to {@code to}.
+   *
+   * @return the best path found, or {@code null} when none can be returned: no route exists within
+   *         the implementation's search bound, or the search failed unexpectedly.
+   * @throws OTPRequestTimeoutException when the request is cancelled. A cancelled search carries no
+   *                                   verdict on whether the leg is routable, so it must propagate
+   *                                   instead of being reported as a {@code null} return.
+   */
+  @Nullable
   GraphPath<State, Edge, Vertex> route(Vertex from, Vertex to);
 }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolStreetRouter.java
@@ -3,6 +3,7 @@ package org.opentripplanner.ext.carpooling.routing;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -18,17 +19,18 @@ import org.slf4j.LoggerFactory;
 /**
  * Street routing service for carpooling insertion evaluation.
  * <p>
- * This router encapsulates all dependencies needed for A* street routing between
- * coordinate pairs during carpool insertion optimization. It handles vertex linking,
- * search configuration, and path selection for CAR mode routing.
+ * This router encapsulates all dependencies needed for A* street routing between two street
+ * vertices during carpool insertion optimization. It handles search configuration and path
+ * selection for CAR mode routing.
  *
  * <h2>Routing Strategy</h2>
  * <ul>
  *   <li><strong>Mode:</strong> CAR mode for both origin and destination</li>
  *   <li><strong>Algorithm:</strong> A* with Euclidean heuristic</li>
  *   <li><strong>Dominance:</strong> Minimum weight</li>
- *   <li><strong>Vertex Linking:</strong> Creates temporary vertices at coordinate locations</li>
- *   <li><strong>Error Handling:</strong> Returns null on routing failure (logged as warning)</li>
+ *   <li><strong>Search Bound:</strong> {@link CarpoolTrip#MAX_TRIP_DURATION}</li>
+ *   <li><strong>Error Handling:</strong> Returns null on routing failure (logged as warning); a
+ *       cancelled request propagates, see {@link CarpoolRouter#route}</li>
  * </ul>
  *
  * @see InsertionEvaluator for usage in insertion evaluation
@@ -52,6 +54,9 @@ public class CarpoolStreetRouter implements CarpoolRouter {
   public GraphPath<State, Edge, Vertex> route(Vertex from, Vertex to) {
     try {
       return carpoolRouting(from, to);
+    } catch (OTPRequestTimeoutException e) {
+      // Rethrown ahead of the catch-all below, which would turn a cancellation into a null return.
+      throw e;
     } catch (Exception e) {
       LOG.warn("Routing failed from {} to {}: {}", from, to, e.getMessage());
       return null;
@@ -70,16 +75,18 @@ public class CarpoolStreetRouter implements CarpoolRouter {
    *
    * @param fromVertex the origin vertex
    * @param toVertex the destination vertex
-   * @return the first (best) path found, or null if no paths exist
+   * @return the first (best) path found, or null if no path reaches the destination within
+   *         {@link CarpoolTrip#MAX_TRIP_DURATION}
    */
   private GraphPath<State, Edge, Vertex> carpoolRouting(Vertex fromVertex, Vertex toVertex) {
     var request = StreetSearchRequest.of().withMode(StreetMode.CAR).build();
     var streetSearch = StreetSearchBuilder.of()
+      .withPreStartHook(OTPRequestTimeoutException::checkForTimeout)
       .withHeuristic(new EuclideanRemainingWeightHeuristic(streetLimitationParametersService))
       // Bound the search at the carpool trip ceiling rather than the passenger request's
       // maxDirectDuration: a driver leg is not a passenger direct trip, and a request-independent
       // bound keeps the cached baseline leg durations request-independent too.
-      .withSkipEdgeStrategy(new DurationSkipEdgeStrategy(CarpoolTrip.MAX_TRIP_DURATION))
+      .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(CarpoolTrip.MAX_TRIP_DURATION))
       .withDominanceFunction(new DominanceFunctions.MinimumWeight())
       .withRequest(request)
       .withFrom(fromVertex)

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/CarpoolTreeStreetRouter.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.opentripplanner.astar.model.GraphPath;
 import org.opentripplanner.astar.model.ShortestPathTree;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.Edge;
 import org.opentripplanner.street.model.vertex.Vertex;
@@ -70,6 +71,7 @@ public class CarpoolTreeStreetRouter implements CarpoolRouter {
       ? StreetSearchRequest.of().withMode(StreetMode.CAR).withArriveBy(true).build()
       : StreetSearchRequest.of().withMode(StreetMode.CAR).build();
     var builder = StreetSearchBuilder.of()
+      .withPreStartHook(OTPRequestTimeoutException::checkForTimeout)
       .withSkipEdgeStrategy(new DurationSkipEdgeStrategy<>(searchLimit))
       .withDominanceFunction(new DominanceFunctions.EarliestArrival())
       .withRequest(streetSearchRequest);
@@ -176,9 +178,11 @@ public class CarpoolTreeStreetRouter implements CarpoolRouter {
    * Results are cached so repeated queries for the same vertex pair are free.
    * The tree for a vertex is computed on the first {@link #route} call that needs it.
    * <p>
-   * The method first looks for a forward tree rooted at {@code from}; if none exists
-   * it falls back to a reverse tree rooted at {@code to}. Returns {@code null} if
-   * neither tree is available or no path exists.
+   * The method first looks for a forward tree rooted at {@code from}; if none exists it falls back
+   * to a reverse tree rooted at {@code to}. At least one of the two endpoints must therefore have
+   * been registered with {@link #addVertex} in the matching direction; a call whose endpoints were
+   * both left unregistered cannot be served and returns {@code null}. A registered endpoint whose
+   * tree does not reach the other endpoint within its search limit returns {@code null} as well.
    */
   @Override
   public GraphPath<State, Edge, Vertex> route(Vertex from, Vertex to) {

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarReachableVertexSnapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/CarReachableVertexSnapper.java
@@ -10,6 +10,7 @@ import org.opentripplanner.astar.spi.SearchTerminationStrategy;
 import org.opentripplanner.astar.spi.SkipEdgeStrategy;
 import org.opentripplanner.astar.strategy.ComposingSkipEdgeStrategy;
 import org.opentripplanner.astar.strategy.DurationSkipEdgeStrategy;
+import org.opentripplanner.framework.application.OTPRequestTimeoutException;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.street.model.StreetMode;
 import org.opentripplanner.street.model.edge.Edge;
@@ -175,6 +176,7 @@ public final class CarReachableVertexSnapper {
       .build();
     // No heuristic is available since there is no fixed destination.
     var builder = StreetSearchBuilder.of()
+      .withPreStartHook(OTPRequestTimeoutException::checkForTimeout)
       .withRequest(request)
       .withSkipEdgeStrategy(
         new ComposingSkipEdgeStrategy<>(scope, new DurationSkipEdgeStrategy<>(maxWalk))
@@ -275,6 +277,10 @@ public final class CarReachableVertexSnapper {
     // The Euclidean heuristic is not appropriate without a fixed destination, and a purpose-built
     // one is out of scope for now, so this runs as plain Dijkstra (f = g).
     var builder = StreetSearchBuilder.of()
+      // Deliberately no cancellation check: this probe starts once per settled vertex of the
+      // enclosing search, so the yield() inside checkForTimeout would dominate it. The no-op is
+      // explicit because an unset hook logs a warning.
+      .withPreStartHook(() -> {})
       .withRequest(arriveBy ? CAR_ARRIVE : CAR_DEPART)
       .withSkipEdgeStrategy(skipEdges)
       .withDominanceFunction(new DominanceFunctions.MinimumWeight())


### PR DESCRIPTION
### Summary

Carpooling street searches now honour request cancellation: every A* in the carpool path gets a withPreStartHook(OTPRequestTimeoutException::checkForTimeout), and CarpoolStreetRouter rethrows the timeout ahead of its catch-all instead of  collapsing it into a null return. That matters because callers memoize null as "unroutable" — in CarpoolingRepository.cachedBaselineRouting across requests, and in CarpoolTreeStreetRouter.pathCache within one — so a cancelled search was   writing a false permanent verdict. The escape probe in CarReachableVertexSnapper deliberately keeps a no-op hook (it starts once per settled vertex of the enclosing search).


### Unit tests

 Added propagateCancellationInsteadOfReturningNull to CarpoolStreetRouterTest (new file), CarpoolTreeStreetRouterTest, and CarReachableVertexSnapperTest: each interrupts, asserts the throw, clears the flag, and asserts the retry succeeds   — pinning both the propagation and the absence of a cached verdict.

### Documentation

Javadoc on CarpoolRouter.route now states the null and @throws contract; CarpoolTreeStreetRouter.route documents the addVertex precondition; stale vertex-linking claims removed from CarpoolStreetRouter. No new config.
