### PR TITLE
Demote noisy carpooling log events

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/filter/DistanceTripFilter.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/filter/DistanceTripFilter.java
@@ -44,11 +44,6 @@ public class DistanceTripFilter implements CarpoolTripFilter {
     var passengerDropoff = request.getPassengerDropoff();
     List<WgsCoordinate> routePoints = trip.routePoints();
 
-    if (routePoints.size() < 2) {
-      LOG.warn("Trip {} has fewer than 2 route points, rejecting", trip.getId());
-      return false;
-    }
-
     for (int i = 0; i < routePoints.size() - 1; i++) {
       WgsCoordinate segmentStart = routePoints.get(i);
       WgsCoordinate segmentEnd = routePoints.get(i + 1);

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
@@ -305,8 +305,8 @@ public class CarpoolItineraryMapper {
    * from the driver's trip origin/destination.
    * <p>
    * If the contact's booking URL cannot be parsed as a valid {@link URI}, the URL is dropped from
-   * the returned {@code BookingInfo} (a malformed URL is logged as a warning and treated as if
-   * the trip published no booking URL at all) and {@link BookingMethod#ONLINE} is omitted from
+   * the returned {@code BookingInfo} (a malformed URL is logged and treated as if the trip
+   * published no booking URL at all) and {@link BookingMethod#ONLINE} is omitted from
    * the booking methods. This keeps the "non-null return ⇒ at least one usable booking method"
    * contract honest: a {@code BookingInfo} is never returned advertising {@code ONLINE} without
    * a URL the user can actually open.
@@ -390,7 +390,7 @@ public class CarpoolItineraryMapper {
    * rather than swallowing them.
    *
    * @return the augmented URL, or {@code null} if the input is not a parseable URI — in which
-   *         case a warning is logged and the caller should drop the URL (and the
+   *         case the failure is logged and the caller should drop the URL (and the
    *         {@link BookingMethod#ONLINE} booking method along with it).
    */
   @Nullable
@@ -419,7 +419,11 @@ public class CarpoolItineraryMapper {
         uri.getFragment()
       ).toString();
     } catch (URISyntaxException e) {
-      LOG.warn("Failed to parse carpool booking URL '{}'; dropping URL from booking info", url, e);
+      LOG.info(
+        "Failed to parse carpool booking URL '{}'; dropping URL from booking info: {}",
+        url,
+        e.getMessage()
+      );
       return null;
     }
   }

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/routing/InsertionEvaluator.java
@@ -129,7 +129,7 @@ public class InsertionEvaluator {
 
     GraphPath<State, Edge, Vertex>[] baselineSegments = routeSegments(tripWithVertices.vertices());
     if (baselineSegments == null) {
-      LOG.error("Could not route baseline segments for trip {}", tripWithVertices.trip().getId());
+      LOG.info("Could not route baseline segments for trip {}", tripWithVertices.trip().getId());
       return List.of();
     }
 
@@ -191,7 +191,7 @@ public class InsertionEvaluator {
   ) {
     GraphPath<State, Edge, Vertex>[] baselineSegments = routeSegments(tripWithVertices.vertices());
     if (baselineSegments == null) {
-      LOG.warn("Could not route baseline for trip {}", tripWithVertices.trip().getId());
+      LOG.info("Could not route baseline for trip {}", tripWithVertices.trip().getId());
       return null;
     }
 

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingService.java
@@ -251,7 +251,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
         carpoolingRequest.getPassengerDropoff()
       );
       if (passengerPickupVertex == null || passengerDropoffVertex == null) {
-        LOG.warn("Could not link passenger origin/destination to graph");
+        LOG.info("Could not link passenger origin/destination to graph");
         return List.of();
       }
 
@@ -413,7 +413,7 @@ public class DefaultCarpoolingService implements CarpoolingService {
       );
 
       if (passengerAccessEgressVertex == null) {
-        LOG.error("Could not link passenger coordinates {} to graph", passengerCoordinates);
+        LOG.info("Could not link passenger coordinates {} to graph", passengerCoordinates);
         return List.of();
       }
 

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
@@ -249,9 +249,9 @@ public class CarpoolSiriMapper {
    * Extracts the total capacity from the EstimatedCalls' ExpectedDepartureCapacities.
    * Expects the cancelled calls to have already been filtered out. Only the first element
    * of each call's capacities list is inspected; additional entries are ignored. Uses the
-   * value from the first call that has it. Logs a warning if calls report different capacity
-   * values. Returns {@link CarpoolTrip#DEFAULT_TOTAL_CAPACITY} if no call has capacity data
-   * or if the value is invalid.
+   * value from the first call that has it; a differing value in a later call is ignored.
+   * Returns {@link CarpoolTrip#DEFAULT_TOTAL_CAPACITY} if no call has capacity data or if
+   * the value is invalid.
    */
   private int extractTotalCapacity(String tripId, List<EstimatedCall> calls) {
     Integer firstCapacity = null;
@@ -271,7 +271,7 @@ public class CarpoolSiriMapper {
         firstCapacity = intValue;
         firstCapacityIndex = i;
       } else if (intValue != firstCapacity) {
-        LOG.warn(
+        LOG.info(
           "Trip {}: totalCapacity differs between calls (call {} has {}, call {} has {})",
           tripId,
           firstCapacityIndex,
@@ -286,7 +286,7 @@ public class CarpoolSiriMapper {
       return DEFAULT_TOTAL_CAPACITY;
     }
     if (firstCapacity <= 0) {
-      LOG.warn(
+      LOG.info(
         "Trip {}: invalid totalCapacity {} at call {}, using default {}",
         tripId,
         firstCapacity,
@@ -310,7 +310,7 @@ public class CarpoolSiriMapper {
       if (onboardCount != null) {
         int value = onboardCount.intValue();
         if (value <= 0) {
-          LOG.warn(
+          LOG.info(
             "Trip {}: invalid onboardCount {}, using default {}",
             tripId,
             value,
@@ -340,9 +340,9 @@ public class CarpoolSiriMapper {
    *   <li>Returns {@link CarpoolStop#DEFAULT_DEVIATION_BUDGET} if either timestamp is missing.
    *       This is intentionally permissive — the absence of a commitment should not block
    *       insertions.</li>
-   *   <li>Returns {@link Duration#ZERO} (and logs a warning) if {@code latestExpectedArrivalTime}
-   *       is before the arrival time — the schedule has slipped past the commitment, so no
-   *       further deviation is acceptable.</li>
+   *   <li>Returns {@link Duration#ZERO} if {@code latestExpectedArrivalTime} is before the
+   *       arrival time — the schedule has slipped past the commitment, so no further deviation
+   *       is acceptable.</li>
    * </ul>
    */
   private Duration extractDeviationBudget(EstimatedCall call) {
@@ -357,7 +357,7 @@ public class CarpoolSiriMapper {
 
     Duration budget = Duration.between(arrivalTime, latestExpected);
     if (budget.isNegative()) {
-      LOG.warn(
+      LOG.info(
         "latestExpectedArrivalTime ({}) is before arrivalTime ({}), using zero deviation budget",
         latestExpected,
         arrivalTime
@@ -380,7 +380,7 @@ public class CarpoolSiriMapper {
     ZonedDateTime lastTime = calls.getLast().getAimedArrivalTime();
 
     if (firstTime == null || lastTime == null) {
-      LOG.warn("Cannot validate call order - missing timing information in first or last call");
+      LOG.info("Cannot validate call order - missing timing information in first or last call");
       return;
     }
 
@@ -402,7 +402,7 @@ public class CarpoolSiriMapper {
         : intermediateCall.getAimedArrivalTime();
 
       if (intermediateTime == null) {
-        LOG.warn("Intermediate call at index {} has no timing information", i);
+        LOG.info("Intermediate call at index {} has no timing information", i);
         continue;
       }
 

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdater.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/SiriETCarpoolingUpdater.java
@@ -139,7 +139,7 @@ public class SiriETCarpoolingUpdater extends PollingGraphUpdater<TransitRealTime
         var estimatedVehicleJourneys = frame.getEstimatedVehicleJourneies();
 
         if (estimatedVehicleJourneys == null || estimatedVehicleJourneys.isEmpty()) {
-          LOG.warn("Received an empty EstimatedJourneyVersionFrame, skipping");
+          LOG.debug("Received an empty EstimatedJourneyVersionFrame, skipping");
           continue;
         }
 
@@ -172,7 +172,11 @@ public class SiriETCarpoolingUpdater extends PollingGraphUpdater<TransitRealTime
       }
       repository.upsertCarpoolTrip(tripWithVertices);
     } catch (Exception e) {
-      LOG.warn("Failed to process EstimatedVehicleJourney", e);
+      LOG.info(
+        "Failed to process EstimatedVehicleJourney {}",
+        estimatedVehicleJourney.getEstimatedVehicleJourneyCode(),
+        e
+      );
     }
   }
 


### PR DESCRIPTION
Demoted most warnings in the carpooling module to info or debug instead, to avoid creating lots of warning because of missing or bad client data. 
