### PR TITLE
Fix NullPointerException in elevator-way processing after #7905

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/ElevatorProcessor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/ElevatorProcessor.java
@@ -207,7 +207,7 @@ class ElevatorProcessor {
       }
       List<OsmLevel> nodeLevels = osmdb.getLevelsForEntity(way);
       List<Long> nodes = Arrays.stream(way.getNodeRefs().toArray())
-        .filter(vertexGenerator::isIntersectionNode)
+        .filter(vertexGenerator::hasIntersectionVertex)
         .boxed()
         .toList();
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexGenerator.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexGenerator.java
@@ -320,7 +320,7 @@ class VertexGenerator {
    * than one OSM way (or way/area boundary) and therefore needs to become a graph vertex.
    */
   boolean isIntersectionNode(long nodeId) {
-    return intersectionNodes.containsKey(nodeId);
+    return intersectionNodes.get(nodeId) != null;
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexGenerator.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/osm/VertexGenerator.java
@@ -318,8 +318,28 @@ class VertexGenerator {
   /**
    * Returns whether the given OSM node id is a shared intersection node, i.e. it appears in more
    * than one OSM way (or way/area boundary) and therefore needs to become a graph vertex.
+   * <p>
+   * This is {@code true} as soon as the node is recorded as a candidate by
+   * {@link #initIntersectionNodes()}, even before a vertex has actually been built for it - the
+   * street-graph-building loop in {@code OsmModule} relies on that to decide where to split a way
+   * while it is still creating vertices. Use {@link #hasIntersectionVertex(long)} if you need to
+   * know whether a vertex has actually been created.
    */
   boolean isIntersectionNode(long nodeId) {
+    return intersectionNodes.containsKey(nodeId);
+  }
+
+  /**
+   * Returns whether a real graph vertex has already been created for the given OSM node id.
+   * <p>
+   * Unlike {@link #isIntersectionNode(long)}, this is only {@code true} once
+   * {@link #getVertexForOsmNode} has actually run for the node - some nodes that are marked as
+   * candidate intersection nodes never get a vertex built, e.g. because every way that would have
+   * built one is skipped by {@code OsmModule}'s street-graph-building loop (not routable, or
+   * de-duplicated away). Use this instead of {@link #isIntersectionNode(long)} when you need to
+   * look up a vertex that must already exist.
+   */
+  boolean hasIntersectionVertex(long nodeId) {
     return intersectionNodes.get(nodeId) != null;
   }
 

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorTest.java
@@ -1,4 +1,4 @@
-package org.opentripplanner.graph_builder.module.osm.moduletests;
+package org.opentripplanner.graph_builder.module.osm.moduletests.elevator;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorWayIntersectionNodeTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorWayIntersectionNodeTest.java
@@ -1,0 +1,84 @@
+package org.opentripplanner.graph_builder.module.osm.moduletests.elevator;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.opentripplanner.osm.model.NodeBuilder.node;
+
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
+import org.opentripplanner.graph_builder.issues.FewerThanTwoIntersectionNodesInElevatorWay;
+import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
+import org.opentripplanner.osm.TestOsmProvider;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
+import org.opentripplanner.street.model.edge.ElevatorHopEdge;
+
+/**
+ * Regression test for a NullPointerException reported after #7905 ("Speed up OSM way
+ * processing"): an elevator way endpoint can be recorded as a candidate intersection node
+ * (because it is referenced by a second way) without ever getting a real graph vertex built for
+ * it.
+ * <p>
+ * In this test, node {@code b} sits at the same coordinate as the elevator way's other endpoint
+ * {@code a} (elevator ways are commonly drawn with zero length, relying only on differing level
+ * tags to distinguish the ends) and carries no node-level "level" tag itself, so the
+ * duplicate-node handling in OsmModule's street-graph-building loop drops it while processing the
+ * elevator way. Node {@code b} is also referenced by a second way that is relevant for routing
+ * (it's a bicycle parking way) but not "routable" in the street-graph sense, so it is skipped by
+ * that same loop entirely. As a result no vertex is ever created for {@code b}, even though it
+ * was recorded as a candidate intersection node while scanning for nodes shared between ways.
+ * <p>
+ * The vertex-generator's intersection-node check must distinguish "candidate, not yet built" from
+ * "has a real vertex" so that elevator-way processing degrades gracefully (reporting a
+ * {@link FewerThanTwoIntersectionNodesInElevatorWay} issue) instead of crashing with a
+ * NullPointerException when it looks up the vertex.
+ */
+class ElevatorWayIntersectionNodeTest {
+
+  @Test
+  void elevatorWayEndpointSharedWithNonRoutableWay() {
+    var a = node(1, new WgsCoordinate(1, 1));
+    // `b` has the same coordinate as `a` and no level tag of its own
+    var b = node(2, new WgsCoordinate(1, 1));
+    var c = node(3, new WgsCoordinate(2, 2));
+    var d = node(4, new WgsCoordinate(3, 3));
+
+    var provider = TestOsmProvider.of()
+      .addWayFromNodes(way -> way.withTag("highway", "elevator").withTag("level", "0;-2"), a, b)
+      .addWayFromNodes(way -> way.withTag("highway", "footway"), a, c)
+      .addWayFromNodes(
+        way -> way.withTag("highway", "construction").withTag("amenity", "bicycle_parking"),
+        b,
+        d
+      )
+      .build();
+    var graph = new Graph();
+    var issueStore = new DefaultDataImportIssueStore();
+
+    OsmModuleTestFactory.of(provider)
+      .withGraph(graph)
+      .builder()
+      .withIssueStore(issueStore)
+      .build()
+      .buildGraph();
+
+    var summarizer = new GraphSummarizer(graph);
+
+    assertWithMessage("Expected no elevator hop edges. Check graph at %s", summarizer.geoJsonUrl())
+      .that(graph.getEdgesOfType(ElevatorHopEdge.class))
+      .isEmpty();
+
+    var issues = issueStore
+      .listIssues()
+      .stream()
+      .filter(FewerThanTwoIntersectionNodesInElevatorWay.class::isInstance)
+      .map(FewerThanTwoIntersectionNodesInElevatorWay.class::cast)
+      .toList();
+    assertWithMessage("Expected exactly one FewerThanTwoIntersectionNodesInElevatorWay issue")
+      .that(issues)
+      .hasSize(1);
+    assertWithMessage("Only node `a` should have gotten a real vertex")
+      .that(issues.getFirst().intersectionNodes())
+      .isEqualTo(1);
+  }
+}

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorWayIntersectionNodeTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorWayIntersectionNodeTest.java
@@ -1,9 +1,11 @@
 package org.opentripplanner.graph_builder.module.osm.moduletests.elevator;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.opentripplanner.osm.model.NodeBuilder.node;
 
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.graph_builder.issue.api.DataImportIssue;
 import org.opentripplanner.graph_builder.issue.service.DefaultDataImportIssueStore;
 import org.opentripplanner.graph_builder.issues.FewerThanTwoIntersectionNodesInElevatorWay;
 import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
@@ -11,7 +13,6 @@ import org.opentripplanner.osm.TestOsmProvider;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.graph.summary.GraphSummarizer;
-import org.opentripplanner.street.model.edge.ElevatorHopEdge;
 
 /**
  * Regression test for a NullPointerException reported after #7905 ("Speed up OSM way
@@ -65,20 +66,10 @@ class ElevatorWayIntersectionNodeTest {
     var summarizer = new GraphSummarizer(graph);
 
     assertWithMessage("Expected no elevator hop edges. Check graph at %s", summarizer.geoJsonUrl())
-      .that(graph.getEdgesOfType(ElevatorHopEdge.class))
-      .isEmpty();
+      .that(summarizer.summarizeEdges())
+      .containsExactly("(1,1) → (2,2) PEDESTRIAN ♿✅", "(2,2) → (1,1) PEDESTRIAN ♿✅");
 
-    var issues = issueStore
-      .listIssues()
-      .stream()
-      .filter(FewerThanTwoIntersectionNodesInElevatorWay.class::isInstance)
-      .map(FewerThanTwoIntersectionNodesInElevatorWay.class::cast)
-      .toList();
-    assertWithMessage("Expected exactly one FewerThanTwoIntersectionNodesInElevatorWay issue")
-      .that(issues)
-      .hasSize(1);
-    assertWithMessage("Only node `a` should have gotten a real vertex")
-      .that(issues.getFirst().intersectionNodes())
-      .isEqualTo(1);
+    var issues = issueStore.listIssues().stream().map(DataImportIssue::getType);
+    assertThat(issues).containsExactly("FewerThanTwoIntersectionNodesInElevatorWay");
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorWayIntersectionNodeTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorWayIntersectionNodeTest.java
@@ -21,13 +21,17 @@ import org.opentripplanner.street.graph.summary.GraphSummarizer;
  * it.
  * <p>
  * In this test, node {@code b} sits at the same coordinate as the elevator way's other endpoint
- * {@code a} (elevator ways are commonly drawn with zero length, relying only on differing level
- * tags to distinguish the ends) and carries no node-level "level" tag itself, so the
+ * {@code a} - a mapping error rather than a legitimate way of tagging an elevator, but one that
+ * does occur in real OSM data - and carries no node-level "level" tag itself, so the
  * duplicate-node handling in OsmModule's street-graph-building loop drops it while processing the
- * elevator way. Node {@code b} is also referenced by a second way that is relevant for routing
- * (it's a bicycle parking way) but not "routable" in the street-graph sense, so it is skipped by
- * that same loop entirely. As a result no vertex is ever created for {@code b}, even though it
- * was recorded as a candidate intersection node while scanning for nodes shared between ways.
+ * elevator way: it never becomes the "from" or "to" node of a street edge there. Node {@code b}
+ * is also referenced by a second way that is relevant for routing (it's a bicycle parking way)
+ * but not "routable" in the street-graph sense, so OsmModule's street-graph-building loop skips
+ * that way entirely too. As a result no vertex is ever created for {@code b}, even though it was
+ * recorded as a candidate intersection node while scanning for nodes shared between ways -
+ * exactly the combination that made {@code ElevatorProcessor} crash: it found {@code b} in its
+ * list of candidate intersection nodes for the elevator way, then failed to look up a vertex that
+ * was never built.
  * <p>
  * The vertex-generator's intersection-node check must distinguish "candidate, not yet built" from
  * "has a real vertex" so that elevator-way processing degrades gracefully (reporting a


### PR DESCRIPTION
## Summary

After #7905 ("Speed up OSM way processing"), graph building could throw:

```
java.lang.NullPointerException: Cannot invoke
"IntersectionVertex.getLabelString()" because "sourceVertex" is null
    at ElevatorProcessor.buildElevatorEdgesFromElevatorWays(ElevatorProcessor.java:260)
```

on real-world data, e.g. https://www.openstreetmap.org/node/2409796062.

### Root cause

`VertexGenerator.intersectionNodes` uses a `null` value as a marker: `initIntersectionNodes()`
pre-records every node shared by 2+ ways as a *candidate* intersection (`put(node, null)`)
before any vertex exists, and `OsmModule`'s street-graph-building loop later overwrites the
`null` with a real `IntersectionVertex` once it actually builds one.

#7905 replaced the field with a Trove primitive map and introduced a single
`isIntersectionNode(long)` check, initially implemented as `containsKey(nodeId)`. A follow-up
commit changed it to `get(nodeId) != null` to fix the NPE - but `isIntersectionNode` has two
different callers that need two different answers:

- `OsmModule`'s street-graph split-decision loop needs "is this a *candidate*
  intersection" (i.e. `containsKey`), since it runs *while* vertices are still being built and
  relies on the up-front candidate marking to know where to split a way.
- `ElevatorProcessor.buildElevatorEdgesFromElevatorWays` needs "does a *real vertex already
  exist*" (i.e. `get() != null`), since it runs after the street graph is built and looks the
  vertex up directly.

The `get() != null` fix satisfied the second caller but broke the first: it silently
regressed two existing tests (`ElevatorTest.elevatorWayWithThreeIntersectionNodes` and
`OsmModuleTest.testBuildGraphDetailed`), since an intersection node not yet visited by the split
loop would never be recognized as one.

### Fix

Split the method in two:
- `isIntersectionNode(long)` - unchanged behavior (`containsKey`), used by `OsmModule`'s
  split-decision loop.
- `hasIntersectionVertex(long)` (new) - `get() != null`, used by `ElevatorProcessor`'s
  post-hoc vertex lookup.

### Testing

- Added `ElevatorWayIntersectionNodeTest`, reproducing the NPE with a minimal synthetic case:
  an elevator way endpoint that coincides (same coordinate, no per-node `level` tag) with the
  way's other endpoint, and is also referenced by a second way that's relevant-for-routing
  (bicycle parking) but not street-routable - so it's marked as a candidate intersection but
  never gets a real vertex built. Verified this test fails with the pre-fix code and with the
  intermediate single-check fix, and passes with the two-method fix.