### PR TITLE
Remove inefficient getEdgesOfType

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/dataoverlay/EdgeUpdaterModule.java
+++ b/application/src/ext/java/org/opentripplanner/ext/dataoverlay/EdgeUpdaterModule.java
@@ -3,6 +3,8 @@ package org.opentripplanner.ext.dataoverlay;
 import org.opentripplanner.ext.dataoverlay.configuration.TimeUnit;
 import org.opentripplanner.graph_builder.model.GraphBuilderModule;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.model.edge.StreetEdge;
+import org.opentripplanner.utils.collection.ListUtils;
 
 /**
  * This class allows updating the graph with the grid data from generic .nc file in accordance with
@@ -31,7 +33,7 @@ public class EdgeUpdaterModule implements GraphBuilderModule {
     GenericEdgeUpdater genericEdgeUpdater = new GenericEdgeUpdater(
       dataFile,
       timeFormat,
-      graph.getStreetEdges()
+      ListUtils.ofIterable(graph.findEdges(StreetEdge.class))
     );
     genericEdgeUpdater.updateEdges();
   }

--- a/application/src/test-fixtures/java/org/opentripplanner/graph_builder/module/islandpruning/IslandPruningUtils.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/graph_builder/module/islandpruning/IslandPruningUtils.java
@@ -5,12 +5,13 @@ import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
 import org.opentripplanner.osm.DefaultOsmProvider;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
 import org.opentripplanner.transit.service.SiteRepository;
 import org.opentripplanner.transit.service.TransitRepository;
 
 class IslandPruningUtils {
 
-  static Graph buildOsmGraph(File osmFile, IslandPruningParameters parameters) {
+  static GraphSummarizer buildOsmGraph(File osmFile, IslandPruningParameters parameters) {
     try {
       var graph = new Graph();
       var osmProvider = new DefaultOsmProvider(osmFile, true);
@@ -25,7 +26,7 @@ class IslandPruningUtils {
 
       prune(graph, parameters);
 
-      return graph;
+      return new GraphSummarizer(graph);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
@@ -20,6 +20,7 @@ import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
 import org.opentripplanner.streetadapter.VertexFactory;
 import org.opentripplanner.transit.service.TransitRepository;
+import org.opentripplanner.utils.collection.ListUtils;
 
 public class VehicleParkingLinkingTest {
 
@@ -77,7 +78,7 @@ public class VehicleParkingLinkingTest {
 
     TestStreetLinkerModule.link(graph, transitRepository);
 
-    var streetLinks = graph.getEdgesOfType(StreetVehicleParkingLink.class);
+    var streetLinks = ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class));
     assertEquals(2, streetLinks.size());
 
     streetLinks.forEach(e ->
@@ -110,7 +111,7 @@ public class VehicleParkingLinkingTest {
 
     TestStreetLinkerModule.link(graph, transitRepository);
 
-    var streetLinks = graph.getEdgesOfType(StreetVehicleParkingLink.class);
+    var streetLinks = ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class));
     assertEquals(4, streetLinks.size());
 
     streetLinks.forEach(e ->
@@ -148,8 +149,8 @@ public class VehicleParkingLinkingTest {
 
     assertEquals(1, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
 
-    assertEquals(1, graph.getEdgesOfType(VehicleParkingEdge.class).size());
-    assertEquals(2, graph.getEdgesOfType(StreetVehicleParkingLink.class).size());
+    assertEquals(1, ListUtils.ofIterable(graph.findEdges(VehicleParkingEdge.class)).size());
+    assertEquals(2, ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class)).size());
   }
 
   @Test
@@ -175,10 +176,10 @@ public class VehicleParkingLinkingTest {
 
     assertEquals(0, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
 
-    assertEquals(0, graph.getEdgesOfType(VehicleParkingEdge.class).size());
-    assertEquals(0, graph.getEdgesOfType(StreetVehicleParkingLink.class).size());
+    assertEquals(0, ListUtils.ofIterable(graph.findEdges(VehicleParkingEdge.class)).size());
+    assertEquals(0, ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class)).size());
 
-    assertEquals(0, graph.getEdgesOfType(StreetVehicleParkingLink.class).size());
+    assertEquals(0, ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class)).size());
     assertEquals(0, vehicleParkingService.listVehicleParkings().size());
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/VehicleParkingLinkingTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.graph_builder.module;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.opentripplanner.core.model.id.FeedScopedIdForTestFactory.id;
@@ -20,7 +21,6 @@ import org.opentripplanner.street.model.vertex.IntersectionVertex;
 import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
 import org.opentripplanner.streetadapter.VertexFactory;
 import org.opentripplanner.transit.service.TransitRepository;
-import org.opentripplanner.utils.collection.ListUtils;
 
 public class VehicleParkingLinkingTest {
 
@@ -78,12 +78,13 @@ public class VehicleParkingLinkingTest {
 
     TestStreetLinkerModule.link(graph, transitRepository);
 
-    var streetLinks = ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class));
-    assertEquals(2, streetLinks.size());
+    assertThat(graph.findEdges(StreetVehicleParkingLink.class)).hasSize(2);
 
-    streetLinks.forEach(e ->
-      assertTrue(e.getFromVertex().equals(parkingVertex) ^ e.getToVertex().equals(parkingVertex))
-    );
+    graph
+      .findEdges(StreetVehicleParkingLink.class)
+      .forEach(e ->
+        assertTrue(e.getFromVertex().equals(parkingVertex) ^ e.getToVertex().equals(parkingVertex))
+      );
   }
 
   @Test
@@ -111,12 +112,13 @@ public class VehicleParkingLinkingTest {
 
     TestStreetLinkerModule.link(graph, transitRepository);
 
-    var streetLinks = ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class));
-    assertEquals(4, streetLinks.size());
+    assertThat(graph.findEdges(StreetVehicleParkingLink.class)).hasSize(4);
 
-    streetLinks.forEach(e ->
-      assertTrue(e.getFromVertex().equals(parkingVertex) ^ e.getToVertex().equals(parkingVertex))
-    );
+    graph
+      .findEdges(StreetVehicleParkingLink.class)
+      .forEach(e ->
+        assertTrue(e.getFromVertex().equals(parkingVertex) ^ e.getToVertex().equals(parkingVertex))
+      );
   }
 
   @Test
@@ -149,8 +151,8 @@ public class VehicleParkingLinkingTest {
 
     assertEquals(1, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
 
-    assertEquals(1, ListUtils.ofIterable(graph.findEdges(VehicleParkingEdge.class)).size());
-    assertEquals(2, ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class)).size());
+    assertThat(graph.findEdges(VehicleParkingEdge.class)).hasSize(1);
+    assertThat(graph.findEdges(StreetVehicleParkingLink.class)).hasSize(2);
   }
 
   @Test
@@ -176,10 +178,10 @@ public class VehicleParkingLinkingTest {
 
     assertEquals(0, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
 
-    assertEquals(0, ListUtils.ofIterable(graph.findEdges(VehicleParkingEdge.class)).size());
-    assertEquals(0, ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class)).size());
+    assertThat(graph.findEdges(VehicleParkingEdge.class)).isEmpty();
+    assertThat(graph.findEdges(StreetVehicleParkingLink.class)).isEmpty();
 
-    assertEquals(0, ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class)).size());
+    assertThat(graph.findEdges(StreetVehicleParkingLink.class)).isEmpty();
     assertEquals(0, vehicleParkingService.listVehicleParkings().size());
   }
 }

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/AdaptivePruningTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/AdaptivePruningTest.java
@@ -7,7 +7,6 @@ import static org.opentripplanner.graph_builder.module.islandpruning.IslandPruni
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.graph.summary.GraphSummarizer;
 import org.opentripplanner.test.support.ResourceLoader;
 

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/AdaptivePruningTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/AdaptivePruningTest.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
 import org.opentripplanner.test.support.ResourceLoader;
 
 /**
@@ -18,7 +19,7 @@ import org.opentripplanner.test.support.ResourceLoader;
  */
 class AdaptivePruningTest {
 
-  private static Graph graph;
+  private static GraphSummarizer graph;
 
   @BeforeAll
   static void setup() {
@@ -37,7 +38,7 @@ class AdaptivePruningTest {
   void distantIslandIsRetained() {
     assertTrue(
       graph
-        .getStreetEdges()
+        .listStreetEdges()
         .stream()
         .map(streetEdge -> streetEdge.getName().toString())
         .collect(Collectors.toSet())
@@ -49,7 +50,7 @@ class AdaptivePruningTest {
   void nearIslandIsRemoved() {
     assertFalse(
       graph
-        .getStreetEdges()
+        .listStreetEdges()
         .stream()
         .map(streetEdge -> streetEdge.getName().toString())
         .collect(Collectors.toSet())
@@ -61,7 +62,7 @@ class AdaptivePruningTest {
   void mainGraphIsNotRemoved() {
     assertTrue(
       graph
-        .getStreetEdges()
+        .listStreetEdges()
         .stream()
         .map(streetEdge -> streetEdge.getName().toString())
         .collect(Collectors.toSet())

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/EscalatorPruningTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/EscalatorPruningTest.java
@@ -17,7 +17,7 @@ class EscalatorPruningTest {
     );
     assertTrue(
       graph
-        .getStreetEdges()
+        .listStreetEdges()
         .stream()
         .map(streetEdge -> streetEdge.getName().toString())
         .collect(Collectors.toSet())

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/PruneNoThruIslandsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/PruneNoThruIslandsTest.java
@@ -9,12 +9,13 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.test.support.ResourceLoader;
 
 class PruneNoThruIslandsTest {
 
-  private static Graph graph;
+  private static GraphSummarizer graph;
 
   @BeforeAll
   static void setup() {
@@ -30,7 +31,7 @@ class PruneNoThruIslandsTest {
   void bicycleIslandsBecomeNoThru() {
     assertTrue(
       graph
-        .getStreetEdges()
+        .listStreetEdges()
         .stream()
         .filter(StreetEdge::isBicycleNoThruTraffic)
         .map(streetEdge -> streetEdge.getName().toString())
@@ -43,7 +44,7 @@ class PruneNoThruIslandsTest {
   void carIslandsBecomeNoThru() {
     assertTrue(
       graph
-        .getStreetEdges()
+        .listStreetEdges()
         .stream()
         .filter(StreetEdge::isMotorVehicleNoThruTraffic)
         .map(streetEdge -> streetEdge.getName().toString())
@@ -56,7 +57,7 @@ class PruneNoThruIslandsTest {
   void pruneFloatingBikeAndWalkIsland() {
     assertFalse(
       graph
-        .getStreetEdges()
+        .listStreetEdges()
         .stream()
         .map(streetEdge -> streetEdge.getName().toString())
         .collect(Collectors.toSet())

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/PruneNoThruIslandsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/islandpruning/PruneNoThruIslandsTest.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.graph.summary.GraphSummarizer;
 import org.opentripplanner.street.model.edge.StreetEdge;
 import org.opentripplanner.test.support.ResourceLoader;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/OsmModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/OsmModuleTest.java
@@ -127,7 +127,7 @@ public class OsmModuleTest {
     assertFalse(iv8.hasDrivingTrafficLight());
 
     Set<VertexPair> edgeEndpoints = new HashSet<>();
-    for (StreetEdge se : gg.getStreetEdges()) {
+    for (StreetEdge se : gg.findEdges(StreetEdge.class)) {
       var endpoints = new VertexPair(se.getFromVertex(), se.getToVertex());
       // Check that we don't get any duplicate edges on this small graph.
       if (edgeEndpoints.contains(endpoints)) {

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilderTest.java
@@ -89,7 +89,8 @@ public class WalkableAreaBuilderTest {
   @MaxAreaNodes(5)
   void testCalculateVerticesArea(TestInfo testInfo) {
     var graph = buildGraph(testInfo);
-    var areas = graph.listAreaEdges()
+    var areas = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(1025307935)))
       .map(AreaEdge::getArea)
@@ -105,7 +106,8 @@ public class WalkableAreaBuilderTest {
   @MaxAreaNodes(5)
   void testSetupCalculateVerticesAreaWithoutVisibility(TestInfo testInfo) {
     var graph = buildGraph(testInfo);
-    var areas = graph.listAreaEdges()
+    var areas = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(1025307935)))
       .map(AreaEdge::getArea)
@@ -124,7 +126,8 @@ public class WalkableAreaBuilderTest {
   void testEntranceStopAreaLinking(TestInfo testInfo) {
     var graph = buildGraph(testInfo);
     // first platform contains isolated node tagged as highway=bus_stop. Those are linked if level matches.
-    var busStopConnection = graph.listAreaEdges()
+    var busStopConnection = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(143853)))
       .map(AreaEdge::getArea)
@@ -133,7 +136,8 @@ public class WalkableAreaBuilderTest {
     assertEquals(1, busStopConnection.size());
 
     // first platform has level 0, entrance below it has level -1 -> no links
-    var entranceAtWrongLevel = graph.listAreaEdges()
+    var entranceAtWrongLevel = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(143850)))
       .map(AreaEdge::getArea)
@@ -142,7 +146,8 @@ public class WalkableAreaBuilderTest {
     assertEquals(0, entranceAtWrongLevel.size());
 
     // second platform and its entrance both default to level zero, entrance gets connected
-    var entranceAtSameLevel = graph.listAreaEdges()
+    var entranceAtSameLevel = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> elevatorVertexConnectedToAreaEdgeHasNodeId(a, 143832))
       .map(AreaEdge::getArea)
@@ -152,7 +157,8 @@ public class WalkableAreaBuilderTest {
 
     // second platform also contains a stop position which is not considered as an entrance
     // therefore it should not get linked
-    var stopPositionConnection = graph.listAreaEdges()
+    var stopPositionConnection = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(143863)))
       .map(AreaEdge::getArea)
@@ -163,7 +169,8 @@ public class WalkableAreaBuilderTest {
     // test that third platform and its entrance get connected
     // and there are not too many connections (to remote platforms)
     // third platform also tests the 'layer' tag
-    var connectionEdges = graph.listAreaEdges()
+    var connectionEdges = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> elevatorVertexConnectedToAreaEdgeHasNodeId(a, 143845))
       .toList();
@@ -173,7 +180,8 @@ public class WalkableAreaBuilderTest {
 
     // test that semicolon separated list of elevator levals works in level matching
     // e.g. 'level'='0;1'
-    var elevatorConnection = graph.listAreaEdges()
+    var elevatorConnection = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> elevatorVertexConnectedToAreaEdgeHasNodeId(a, 143861))
       .map(AreaEdge::getArea)
@@ -183,7 +191,8 @@ public class WalkableAreaBuilderTest {
 
     // first platform area has ref tag. Check that it is available in
     // DefaultOsmInfoGraphBuildRepository
-    var areaGroups = graph.listAreaEdges()
+    var areaGroups = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(143846)))
       .map(AreaEdge::getArea)
@@ -204,7 +213,8 @@ public class WalkableAreaBuilderTest {
   @MaxAreaNodes(50)
   void testSeveralIntersections(TestInfo testInfo) {
     var graph = buildGraph(testInfo);
-    var areas = graph.listAreaEdges()
+    var areas = graph
+      .listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(2522105666L)))
       .map(AreaEdge::getArea)

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilderTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/WalkableAreaBuilderTest.java
@@ -24,6 +24,7 @@ import org.opentripplanner.osm.DefaultOsmProvider;
 import org.opentripplanner.osm.model.OsmLevel;
 import org.opentripplanner.service.osminfo.internal.DefaultOsmInfoGraphBuildRepository;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.street.graph.summary.GraphSummarizer;
 import org.opentripplanner.street.model.edge.AreaEdge;
 import org.opentripplanner.street.model.vertex.VertexLabel;
 import org.opentripplanner.street.model.vertex.VertexLabel.VertexWithEntityLabel;
@@ -33,7 +34,7 @@ public class WalkableAreaBuilderTest {
 
   private DefaultOsmInfoGraphBuildRepository osmInfoRepository;
 
-  public Graph buildGraph(final TestInfo testInfo) {
+  public GraphSummarizer buildGraph(final TestInfo testInfo) {
     var graph = new Graph();
     final Method testMethod = testInfo.getTestMethod().get();
     final String osmFile = testMethod.getAnnotation(OsmFile.class).value();
@@ -77,7 +78,7 @@ public class WalkableAreaBuilderTest {
       : walkableAreaBuilder::buildWithoutVisibility;
 
     areaGroups.forEach(build);
-    return graph;
+    return new GraphSummarizer(graph);
   }
 
   // -- Tests --
@@ -88,8 +89,7 @@ public class WalkableAreaBuilderTest {
   @MaxAreaNodes(5)
   void testCalculateVerticesArea(TestInfo testInfo) {
     var graph = buildGraph(testInfo);
-    var areas = graph
-      .getEdgesOfType(AreaEdge.class)
+    var areas = graph.listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(1025307935)))
       .map(AreaEdge::getArea)
@@ -105,8 +105,7 @@ public class WalkableAreaBuilderTest {
   @MaxAreaNodes(5)
   void testSetupCalculateVerticesAreaWithoutVisibility(TestInfo testInfo) {
     var graph = buildGraph(testInfo);
-    var areas = graph
-      .getEdgesOfType(AreaEdge.class)
+    var areas = graph.listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(1025307935)))
       .map(AreaEdge::getArea)
@@ -125,8 +124,7 @@ public class WalkableAreaBuilderTest {
   void testEntranceStopAreaLinking(TestInfo testInfo) {
     var graph = buildGraph(testInfo);
     // first platform contains isolated node tagged as highway=bus_stop. Those are linked if level matches.
-    var busStopConnection = graph
-      .getEdgesOfType(AreaEdge.class)
+    var busStopConnection = graph.listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(143853)))
       .map(AreaEdge::getArea)
@@ -135,8 +133,7 @@ public class WalkableAreaBuilderTest {
     assertEquals(1, busStopConnection.size());
 
     // first platform has level 0, entrance below it has level -1 -> no links
-    var entranceAtWrongLevel = graph
-      .getEdgesOfType(AreaEdge.class)
+    var entranceAtWrongLevel = graph.listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(143850)))
       .map(AreaEdge::getArea)
@@ -145,8 +142,7 @@ public class WalkableAreaBuilderTest {
     assertEquals(0, entranceAtWrongLevel.size());
 
     // second platform and its entrance both default to level zero, entrance gets connected
-    var entranceAtSameLevel = graph
-      .getEdgesOfType(AreaEdge.class)
+    var entranceAtSameLevel = graph.listAreaEdges()
       .stream()
       .filter(a -> elevatorVertexConnectedToAreaEdgeHasNodeId(a, 143832))
       .map(AreaEdge::getArea)
@@ -156,8 +152,7 @@ public class WalkableAreaBuilderTest {
 
     // second platform also contains a stop position which is not considered as an entrance
     // therefore it should not get linked
-    var stopPositionConnection = graph
-      .getEdgesOfType(AreaEdge.class)
+    var stopPositionConnection = graph.listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(143863)))
       .map(AreaEdge::getArea)
@@ -168,8 +163,7 @@ public class WalkableAreaBuilderTest {
     // test that third platform and its entrance get connected
     // and there are not too many connections (to remote platforms)
     // third platform also tests the 'layer' tag
-    var connectionEdges = graph
-      .getEdgesOfType(AreaEdge.class)
+    var connectionEdges = graph.listAreaEdges()
       .stream()
       .filter(a -> elevatorVertexConnectedToAreaEdgeHasNodeId(a, 143845))
       .toList();
@@ -179,8 +173,7 @@ public class WalkableAreaBuilderTest {
 
     // test that semicolon separated list of elevator levals works in level matching
     // e.g. 'level'='0;1'
-    var elevatorConnection = graph
-      .getEdgesOfType(AreaEdge.class)
+    var elevatorConnection = graph.listAreaEdges()
       .stream()
       .filter(a -> elevatorVertexConnectedToAreaEdgeHasNodeId(a, 143861))
       .map(AreaEdge::getArea)
@@ -190,8 +183,7 @@ public class WalkableAreaBuilderTest {
 
     // first platform area has ref tag. Check that it is available in
     // DefaultOsmInfoGraphBuildRepository
-    var areaGroups = graph
-      .getEdgesOfType(AreaEdge.class)
+    var areaGroups = graph.listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(143846)))
       .map(AreaEdge::getArea)
@@ -212,8 +204,7 @@ public class WalkableAreaBuilderTest {
   @MaxAreaNodes(50)
   void testSeveralIntersections(TestInfo testInfo) {
     var graph = buildGraph(testInfo);
-    var areas = graph
-      .getEdgesOfType(AreaEdge.class)
+    var areas = graph.listAreaEdges()
       .stream()
       .filter(a -> a.getToVertex().getLabel().equals(VertexLabel.osm(2522105666L)))
       .map(AreaEdge::getArea)

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorTest.java
@@ -30,6 +30,7 @@ import org.opentripplanner.street.model.vertex.ElevatorHopVertex;
 import org.opentripplanner.street.model.vertex.OsmEntityType;
 import org.opentripplanner.street.model.vertex.OsmVertex;
 import org.opentripplanner.streetadapter.VertexFactory;
+import org.opentripplanner.utils.collection.ListUtils;
 
 class ElevatorTest {
 
@@ -42,7 +43,7 @@ class ElevatorTest {
 
     osmModule.buildGraph();
 
-    var edges = graph.getEdgesOfType(ElevatorHopEdge.class);
+    var edges = ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class));
     assertThat(edges).hasSize(2);
     for (var edge : edges) {
       assertThat(edge.getTravelTime()).hasValue(Duration.ofSeconds(62));
@@ -66,7 +67,7 @@ class ElevatorTest {
 
     OsmModuleTestFactory.of(provider).withGraph(graph).builder().build().buildGraph();
 
-    var edges = graph.getEdgesOfType(ElevatorHopEdge.class);
+    var edges = ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class));
     assertThat(edges).hasSize(2);
     for (var edge : edges) {
       assertThat(edge.getTravelTime()).hasValue(Duration.ofSeconds(62));
@@ -89,7 +90,7 @@ class ElevatorTest {
 
     OsmModuleTestFactory.of(provider).withGraph(graph).builder().build().buildGraph();
 
-    var edges = graph.getEdgesOfType(ElevatorHopEdge.class);
+    var edges = ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class));
     assertThat(edges).hasSize(2);
     for (var edge : edges) {
       assertEquals(edge.getLevels(), 0.0);
@@ -214,11 +215,10 @@ class ElevatorTest {
     int streetEdgeCount = 8;
     assertEquals(expectedEdgeSet.size() + streetEdgeCount, graph.getEdges().size());
 
-    graph
-      .getEdgesOfType(ElevatorHopEdge.class)
+    ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class))
       .stream()
       .forEach(edge -> elevatorHopEdgeLevels.put(edge, edge.getLevels()));
-    for (var edge : graph.getEdgesOfType(ElevatorHopEdge.class)) {
+    for (var edge : ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class))) {
       assertEquals(edge.getLevels(), elevatorHopEdgeLevels.get(edge));
     }
   }
@@ -381,7 +381,7 @@ class ElevatorTest {
 
     OsmModuleTestFactory.of(provider).withGraph(graph).builder().build().buildGraph();
 
-    var elevatorHopEdges = graph.getEdgesOfType(ElevatorHopEdge.class);
+    var elevatorHopEdges = ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class));
     assertThat(elevatorHopEdges).hasSize(4);
     var elevatorHopVertices = graph
       .getVerticesOfType(ElevatorHopVertex.class)
@@ -412,7 +412,7 @@ class ElevatorTest {
       .build()
       .buildGraph();
 
-    var elevatorHopEdges = graph.getEdgesOfType(ElevatorHopEdge.class);
+    var elevatorHopEdges = ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class));
     assertThat(elevatorHopEdges).hasSize(0);
 
     var issues = issueStore
@@ -478,22 +478,19 @@ class ElevatorTest {
   private Set<String> getActualEdgeSet(Graph graph) {
     Set<String> actualEdgeSet = new HashSet<>();
     actualEdgeSet.addAll(
-      graph
-        .getEdgesOfType(ElevatorBoardEdge.class)
+      ListUtils.ofIterable(graph.findEdges(ElevatorBoardEdge.class))
         .stream()
         .map(edge -> convertEdgeToVertexLabelString(edge))
         .toList()
     );
     actualEdgeSet.addAll(
-      graph
-        .getEdgesOfType(ElevatorAlightEdge.class)
+      ListUtils.ofIterable(graph.findEdges(ElevatorAlightEdge.class))
         .stream()
         .map(edge -> convertEdgeToVertexLabelString(edge))
         .toList()
     );
     actualEdgeSet.addAll(
-      graph
-        .getEdgesOfType(ElevatorHopEdge.class)
+      ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class))
         .stream()
         .map(edge -> convertEdgeToVertexLabelString(edge))
         .toList()

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorTest.java
@@ -381,8 +381,7 @@ class ElevatorTest {
 
     OsmModuleTestFactory.of(provider).withGraph(graph).builder().build().buildGraph();
 
-    var elevatorHopEdges = ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class));
-    assertThat(elevatorHopEdges).hasSize(4);
+    assertThat(graph.findEdges(ElevatorHopEdge.class)).hasSize(4);
     var elevatorHopVertices = graph
       .getVerticesOfType(ElevatorHopVertex.class)
       .stream()
@@ -412,8 +411,7 @@ class ElevatorTest {
       .build()
       .buildGraph();
 
-    var elevatorHopEdges = ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class));
-    assertThat(elevatorHopEdges).hasSize(0);
+    assertThat(graph.findEdges(ElevatorHopEdge.class)).isEmpty();
 
     var issues = issueStore
       .listIssues()

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/ElevatorTest.java
@@ -31,6 +31,7 @@ import org.opentripplanner.street.model.vertex.OsmEntityType;
 import org.opentripplanner.street.model.vertex.OsmVertex;
 import org.opentripplanner.streetadapter.VertexFactory;
 import org.opentripplanner.utils.collection.ListUtils;
+import org.opentripplanner.utils.collection.StreamUtils;
 
 class ElevatorTest {
 
@@ -476,20 +477,17 @@ class ElevatorTest {
   private Set<String> getActualEdgeSet(Graph graph) {
     Set<String> actualEdgeSet = new HashSet<>();
     actualEdgeSet.addAll(
-      ListUtils.ofIterable(graph.findEdges(ElevatorBoardEdge.class))
-        .stream()
+      StreamUtils.ofIterable(graph.findEdges(ElevatorBoardEdge.class))
         .map(edge -> convertEdgeToVertexLabelString(edge))
         .toList()
     );
     actualEdgeSet.addAll(
-      ListUtils.ofIterable(graph.findEdges(ElevatorAlightEdge.class))
-        .stream()
+      StreamUtils.ofIterable(graph.findEdges(ElevatorAlightEdge.class))
         .map(edge -> convertEdgeToVertexLabelString(edge))
         .toList()
     );
     actualEdgeSet.addAll(
-      ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class))
-        .stream()
+      StreamUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class))
         .map(edge -> convertEdgeToVertexLabelString(edge))
         .toList()
     );

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
@@ -30,6 +30,7 @@ import org.opentripplanner.updater.spi.DataSource;
 import org.opentripplanner.updater.spi.WriteDomain;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
 import org.opentripplanner.updater.spi.WriteToGraphCallbacks;
+import org.opentripplanner.utils.collection.ListUtils;
 import org.opentripplanner.utils.lang.RunnableUtils;
 
 class VehicleParkingUpdaterTest {
@@ -282,7 +283,7 @@ class VehicleParkingUpdaterTest {
 
   private void assertVehicleParkingNotLinked() {
     assertEquals(0, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
-    assertEquals(0, graph.getEdgesOfType(StreetVehicleParkingLink.class).size());
-    assertEquals(0, graph.getEdgesOfType(VehicleParkingEdge.class).size());
+    assertEquals(0, ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class)).size());
+    assertEquals(0, ListUtils.ofIterable(graph.findEdges(VehicleParkingEdge.class)).size());
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/vehicle_parking/VehicleParkingUpdaterTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.updater.vehicle_parking;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +31,6 @@ import org.opentripplanner.updater.spi.DataSource;
 import org.opentripplanner.updater.spi.WriteDomain;
 import org.opentripplanner.updater.spi.WriteToGraphCallback;
 import org.opentripplanner.updater.spi.WriteToGraphCallbacks;
-import org.opentripplanner.utils.collection.ListUtils;
 import org.opentripplanner.utils.lang.RunnableUtils;
 
 class VehicleParkingUpdaterTest {
@@ -283,7 +283,7 @@ class VehicleParkingUpdaterTest {
 
   private void assertVehicleParkingNotLinked() {
     assertEquals(0, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
-    assertEquals(0, ListUtils.ofIterable(graph.findEdges(StreetVehicleParkingLink.class)).size());
-    assertEquals(0, ListUtils.ofIterable(graph.findEdges(VehicleParkingEdge.class)).size());
+    assertThat(graph.findEdges(StreetVehicleParkingLink.class)).isEmpty();
+    assertThat(graph.findEdges(VehicleParkingEdge.class)).isEmpty();
   }
 }

--- a/street/src/main/java/org/opentripplanner/street/graph/Graph.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/Graph.java
@@ -219,19 +219,6 @@ public class Graph implements Serializable {
   }
 
   /**
-   * Note: Under concurrent modification this method may return edges that have been removed from
-   * the graph or not return edges that have been added to the graph after this method has been
-   * called.
-   */
-  public <T extends Edge> List<T> getEdgesOfType(Class<T> cls) {
-    return this.getEdges()
-      .stream()
-      .filter(cls::isInstance)
-      .map(cls::cast)
-      .collect(Collectors.toList());
-  }
-
-  /**
    * Lazily iterate over all edges of a certain type in the graph, without materializing an
    * intermediate collection. Walks the vertices and yielding only the ones that are instances
    * of {@code clazz}.

--- a/street/src/main/java/org/opentripplanner/street/graph/Graph.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/Graph.java
@@ -250,13 +250,6 @@ public class Graph implements Serializable {
       .map(clazz::cast)::iterator;
   }
 
-  /**
-   * Return only the StreetEdges in the graph.
-   */
-  public Collection<StreetEdge> getStreetEdges() {
-    return getEdgesOfType(StreetEdge.class);
-  }
-
   public boolean containsVertex(Vertex v) {
     return (v != null) && vertices.get(v.getLabel()) == v;
   }

--- a/street/src/main/java/org/opentripplanner/street/graph/summary/GraphSummarizer.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/summary/GraphSummarizer.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
-import org.jspecify.annotations.NonNull;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.edge.AreaEdge;
 import org.opentripplanner.street.model.edge.Edge;
@@ -103,7 +102,7 @@ public class GraphSummarizer {
     return graph;
   }
 
-  private @NonNull Stream<Edge> distinctEdges() {
+  private Stream<Edge> distinctEdges() {
     return graph
       .getVertices()
       .stream()

--- a/street/src/main/java/org/opentripplanner/street/graph/summary/GraphSummarizer.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/summary/GraphSummarizer.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
 import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.edge.AreaEdge;
 import org.opentripplanner.street.model.edge.Edge;
@@ -56,16 +57,18 @@ public class GraphSummarizer {
    * outgoing.
    */
   public List<Edge> listEdges() {
-    return graph
-      .getVertices()
-      .stream()
-      .flatMap(v -> Stream.concat(v.getOutgoing().stream(), v.getIncoming().stream()))
-      .distinct()
-      .toList();
+    return distinctEdges().toList();
   }
 
   public List<AreaEdge> listAreaEdges() {
-    return graph.getEdgesOfType(AreaEdge.class);
+    return findEdges(AreaEdge.class);
+  }
+
+  /**
+   * Return all edges of a certain type in the graph.
+   */
+  public <T extends Edge> List<T> findEdges(Class<T> cls) {
+    return distinctEdges().filter(cls::isInstance).map(cls::cast).toList();
   }
 
   public String geoJsonUrl() {
@@ -98,5 +101,13 @@ public class GraphSummarizer {
 
   public Graph graph() {
     return graph;
+  }
+
+  private @NonNull Stream<Edge> distinctEdges() {
+    return graph
+      .getVertices()
+      .stream()
+      .flatMap(v -> Stream.concat(v.getOutgoing().stream(), v.getIncoming().stream()))
+      .distinct();
   }
 }

--- a/street/src/test/java/org/opentripplanner/street/graph/GraphTest.java
+++ b/street/src/test/java/org/opentripplanner/street/graph/GraphTest.java
@@ -21,6 +21,7 @@ import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.model.vertex.VertexLabel;
+import org.opentripplanner.utils.collection.ListUtils;
 
 class GraphTest {
 
@@ -104,7 +105,7 @@ class GraphTest {
     allEdges.add(FreeEdge.createFreeEdge(c, b));
     allEdges.add(FreeEdge.createFreeEdge(c, a));
 
-    Set<StreetEdge> edges = new HashSet<>(g.getStreetEdges());
+    var edges = ListUtils.ofIterable(g.findEdges(StreetEdge.class));
     assertEquals(0, edges.size());
   }
 
@@ -125,9 +126,9 @@ class GraphTest {
     allStreetEdges.add(edge(c, b, 1.0));
     allStreetEdges.add(edge(c, a, 1.0));
 
-    Set<StreetEdge> edges = new HashSet<>(g.getStreetEdges());
+    var edges = ListUtils.ofIterable(g.findEdges(StreetEdge.class));
     assertEquals(4, edges.size());
-    assertEquals(allStreetEdges, edges);
+    assertThat(allStreetEdges).containsExactlyElementsIn(edges);
   }
 
   @Test

--- a/street/src/test/java/org/opentripplanner/street/graph/GraphTest.java
+++ b/street/src/test/java/org/opentripplanner/street/graph/GraphTest.java
@@ -21,7 +21,6 @@ import org.opentripplanner.street.model.edge.StreetEdgeBuilder;
 import org.opentripplanner.street.model.vertex.StreetVertex;
 import org.opentripplanner.street.model.vertex.Vertex;
 import org.opentripplanner.street.model.vertex.VertexLabel;
-import org.opentripplanner.utils.collection.ListUtils;
 
 class GraphTest {
 
@@ -105,8 +104,7 @@ class GraphTest {
     allEdges.add(FreeEdge.createFreeEdge(c, b));
     allEdges.add(FreeEdge.createFreeEdge(c, a));
 
-    var edges = ListUtils.ofIterable(g.findEdges(StreetEdge.class));
-    assertEquals(0, edges.size());
+    assertThat(g.findEdges(StreetEdge.class)).isEmpty();
   }
 
   @Test
@@ -126,9 +124,7 @@ class GraphTest {
     allStreetEdges.add(edge(c, b, 1.0));
     allStreetEdges.add(edge(c, a, 1.0));
 
-    var edges = ListUtils.ofIterable(g.findEdges(StreetEdge.class));
-    assertEquals(4, edges.size());
-    assertThat(allStreetEdges).containsExactlyElementsIn(edges);
+    assertThat(g.findEdges(StreetEdge.class)).containsExactlyElementsIn(allStreetEdges);
   }
 
   @Test

--- a/street/src/test/java/org/opentripplanner/street/linking/VehicleParkingHelperTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/VehicleParkingHelperTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.street.linking;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -15,7 +16,6 @@ import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.StreetModelFactory;
 import org.opentripplanner.street.model.edge.VehicleParkingEdge;
 import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
-import org.opentripplanner.utils.collection.ListUtils;
 
 class VehicleParkingHelperTest {
 
@@ -65,7 +65,7 @@ class VehicleParkingHelperTest {
     new VehicleParkingHelper(graph).linkVehicleParkingToGraph(vehicleParking);
 
     assertEquals(3, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
-    assertEquals(7, ListUtils.ofIterable(graph.findEdges(VehicleParkingEdge.class)).size());
+    assertThat(graph.findEdges(VehicleParkingEdge.class)).hasSize(7);
   }
 
   private VehicleParking createParingWithEntrances(int entranceNumber) {

--- a/street/src/test/java/org/opentripplanner/street/linking/VehicleParkingHelperTest.java
+++ b/street/src/test/java/org/opentripplanner/street/linking/VehicleParkingHelperTest.java
@@ -15,6 +15,7 @@ import org.opentripplanner.street.graph.Graph;
 import org.opentripplanner.street.model.StreetModelFactory;
 import org.opentripplanner.street.model.edge.VehicleParkingEdge;
 import org.opentripplanner.street.model.vertex.VehicleParkingEntranceVertex;
+import org.opentripplanner.utils.collection.ListUtils;
 
 class VehicleParkingHelperTest {
 
@@ -64,7 +65,7 @@ class VehicleParkingHelperTest {
     new VehicleParkingHelper(graph).linkVehicleParkingToGraph(vehicleParking);
 
     assertEquals(3, graph.getVerticesOfType(VehicleParkingEntranceVertex.class).size());
-    assertEquals(7, graph.getEdgesOfType(VehicleParkingEdge.class).size());
+    assertEquals(7, ListUtils.ofIterable(graph.findEdges(VehicleParkingEdge.class)).size());
   }
 
   private VehicleParking createParingWithEntrances(int entranceNumber) {

--- a/utils/src/main/java/org/opentripplanner/utils/collection/ListUtils.java
+++ b/utils/src/main/java/org/opentripplanner/utils/collection/ListUtils.java
@@ -30,7 +30,7 @@ public class ListUtils {
   /**
    * Put all elements in the iterable into a list.
    */
-  public static <T> List<T> ofIterable(Iterable<T> iterable){
+  public static <T> List<T> ofIterable(Iterable<T> iterable) {
     var ret = new ArrayList<T>();
     iterable.forEach(ret::add);
     return ret;

--- a/utils/src/main/java/org/opentripplanner/utils/collection/ListUtils.java
+++ b/utils/src/main/java/org/opentripplanner/utils/collection/ListUtils.java
@@ -28,6 +28,15 @@ public class ListUtils {
   }
 
   /**
+   * Put all elements in the iterable into a list.
+   */
+  public static <T> List<T> ofIterable(Iterable<T> iterable){
+    var ret = new ArrayList<T>();
+    iterable.forEach(ret::add);
+    return ret;
+  }
+
+  /**
    * Combine a number of collections into a single list.
    */
   @SafeVarargs

--- a/utils/src/main/java/org/opentripplanner/utils/collection/StreamUtils.java
+++ b/utils/src/main/java/org/opentripplanner/utils/collection/StreamUtils.java
@@ -2,6 +2,7 @@ package org.opentripplanner.utils.collection;
 
 import java.util.Collection;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
 public class StreamUtils {
@@ -15,5 +16,12 @@ public class StreamUtils {
     } else {
       return value.stream();
     }
+  }
+
+  /**
+   * Converts the given {@code Iterable} into a sequential {@code Stream}.
+   */
+  public static <T> Stream<T> ofIterable(Iterable<T> iterable) {
+    return StreamSupport.stream(iterable.spliterator(), false);
   }
 }


### PR DESCRIPTION
Follow-up to #7906.

Removes the inefficient `Graph.getEdgesOfType` (which materialized `Graph.getEdges()` into a
`HashSet` and then filtered/cast by type) and moves the equivalent, more efficient logic to
`GraphSummarizer`, built on top of the lazy `Graph.findEdges` iteration added in #7906.

All call sites are adjusted to either use `Graph.findEdges` (materializing with
`ListUtils.ofIterable` where a `List` is actually needed) or the method on `GraphSummarizer`.
These call sites were almost exclusively tests.

## Test plan

- [x] `mvn test` for the affected modules (`street`, `application`)