### PR TITLE
Add maplibre-gl to deps optimizer

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     outDir: 'output',
     emptyOutDir: true,
   },
+  optimizeDeps: {
+    exclude: ['maplibre-gl'],
+  },
   // @ts-ignore
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
### Summary

Yesterday I upgrade maplibre-gl to version 6, however I neglected to execute `npm install` to actually run the new version.

Therefore I missed that the lines are no longer correctly drawn onto the map.

It turns out that the build process needs to be adjusted because the library is now bundled in a different way.

@testower Can you please check this out and test it a bit, so this debacle doesn't repeat?