### PR TITLE
Change APIs to properly support alerts with multiple active periods

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AlertImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AlertImpl.java
@@ -20,6 +20,7 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLAlertEffectType;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLAlertSeverityLevelType;
 import org.opentripplanner.apis.gtfs.mapping.AlertCauseMapper;
+import org.opentripplanner.apis.gtfs.model.OpenEndedOffsetDateTimeRange;
 import org.opentripplanner.apis.gtfs.model.RouteTypeModel;
 import org.opentripplanner.apis.gtfs.model.StopOnRouteModel;
 import org.opentripplanner.apis.gtfs.model.StopOnTripModel;
@@ -43,6 +44,20 @@ import org.opentripplanner.transit.service.TransitService;
 public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
 
   private static final String FALLBACK_EMPTY_STRING = "";
+
+  @Override
+  public DataFetcher<Iterable<OpenEndedOffsetDateTimeRange>> activityPeriods() {
+    return environment -> {
+      var zoneId = getTransitService(environment).getTimeZone();
+      return getSource(environment)
+        .calendar()
+        .timePeriods()
+        .stream()
+        .map(period -> OpenEndedOffsetDateTimeRange.of(period, zoneId))
+        .sorted(OpenEndedOffsetDateTimeRange.CHRONOLOGICAL_ORDER)
+        .toList();
+    };
+  }
 
   @Override
   public DataFetcher<Agency> agency() {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AlertImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/AlertImpl.java
@@ -20,7 +20,7 @@ import org.opentripplanner.apis.gtfs.generated.GraphQLTypes;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLAlertEffectType;
 import org.opentripplanner.apis.gtfs.generated.GraphQLTypes.GraphQLAlertSeverityLevelType;
 import org.opentripplanner.apis.gtfs.mapping.AlertCauseMapper;
-import org.opentripplanner.apis.gtfs.model.OpenEndedOffsetDateTimeRange;
+import org.opentripplanner.apis.gtfs.model.OffsetDateTimeRange;
 import org.opentripplanner.apis.gtfs.model.RouteTypeModel;
 import org.opentripplanner.apis.gtfs.model.StopOnRouteModel;
 import org.opentripplanner.apis.gtfs.model.StopOnTripModel;
@@ -46,15 +46,15 @@ public class AlertImpl implements GraphQLDataFetchers.GraphQLAlert {
   private static final String FALLBACK_EMPTY_STRING = "";
 
   @Override
-  public DataFetcher<Iterable<OpenEndedOffsetDateTimeRange>> activityPeriods() {
+  public DataFetcher<Iterable<OffsetDateTimeRange>> activityPeriods() {
     return environment -> {
       var zoneId = getTransitService(environment).getTimeZone();
       return getSource(environment)
         .calendar()
         .timePeriods()
         .stream()
-        .map(period -> OpenEndedOffsetDateTimeRange.of(period, zoneId))
-        .sorted(OpenEndedOffsetDateTimeRange.CHRONOLOGICAL_ORDER)
+        .map(period -> OffsetDateTimeRange.of(period, zoneId))
+        .sorted(OffsetDateTimeRange.CHRONOLOGICAL_ORDER)
         .toList();
     };
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -32,6 +32,7 @@ import org.opentripplanner.apis.gtfs.model.CanceledTripsSummary;
 import org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryPattern;
 import org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryRoute;
 import org.opentripplanner.apis.gtfs.model.FeedPublisher;
+import org.opentripplanner.apis.gtfs.model.OpenEndedOffsetDateTimeRange;
 import org.opentripplanner.apis.gtfs.model.PlanPageInfo;
 import org.opentripplanner.apis.gtfs.model.RealTimeTripStateModel;
 import org.opentripplanner.apis.gtfs.model.RideHailingProvider;
@@ -106,6 +107,7 @@ public class GraphQLDataFetchers {
 
   /** Alert of a current or upcoming disruption in public transportation */
   public interface GraphQLAlert {
+    public DataFetcher<Iterable<OpenEndedOffsetDateTimeRange>> activityPeriods();
     public DataFetcher<Agency> agency();
     public DataFetcher<GraphQLAlertCauseType> alertCause();
     public DataFetcher<String> alertDescriptionText();
@@ -559,6 +561,18 @@ public class GraphQLDataFetchers {
    */
   public interface GraphQLNotice {
     public DataFetcher<String> text();
+  }
+
+  /**
+   * A range of time which can be open in either direction.
+   *
+   * The range is half-open, which means that the start is included in the range but the end is not.
+   * A `null` start means that the range extends indefinitely into the past and a `null` end means
+   * that it extends indefinitely into the future.
+   */
+  public interface GraphQLOpenEndedOffsetDateTimeRange {
+    public DataFetcher<java.time.OffsetDateTime> end();
+    public DataFetcher<java.time.OffsetDateTime> start();
   }
 
   public interface GraphQLOpeningHours {

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -32,7 +32,7 @@ import org.opentripplanner.apis.gtfs.model.CanceledTripsSummary;
 import org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryPattern;
 import org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryRoute;
 import org.opentripplanner.apis.gtfs.model.FeedPublisher;
-import org.opentripplanner.apis.gtfs.model.OpenEndedOffsetDateTimeRange;
+import org.opentripplanner.apis.gtfs.model.OffsetDateTimeRange;
 import org.opentripplanner.apis.gtfs.model.PlanPageInfo;
 import org.opentripplanner.apis.gtfs.model.RealTimeTripStateModel;
 import org.opentripplanner.apis.gtfs.model.RideHailingProvider;
@@ -107,7 +107,7 @@ public class GraphQLDataFetchers {
 
   /** Alert of a current or upcoming disruption in public transportation */
   public interface GraphQLAlert {
-    public DataFetcher<Iterable<OpenEndedOffsetDateTimeRange>> activityPeriods();
+    public DataFetcher<Iterable<OffsetDateTimeRange>> activityPeriods();
     public DataFetcher<Agency> agency();
     public DataFetcher<GraphQLAlertCauseType> alertCause();
     public DataFetcher<String> alertDescriptionText();
@@ -570,7 +570,7 @@ public class GraphQLDataFetchers {
    * A `null` start means that the range extends indefinitely into the past and a `null` end means
    * that it extends indefinitely into the future.
    */
-  public interface GraphQLOpenEndedOffsetDateTimeRange {
+  public interface GraphQLOffsetDateTimeRange {
     public DataFetcher<java.time.OffsetDateTime> end();
     public DataFetcher<java.time.OffsetDateTime> start();
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/GraphQLDataFetchers.java
@@ -564,9 +564,9 @@ public class GraphQLDataFetchers {
   }
 
   /**
-   * A range of time which can be open in either direction.
+   * A range of time which can be unbounded in either direction.
    *
-   * The range is half-open, which means that the start is included in the range but the end is not.
+   * The start of the range is inclusive and the end is exclusive.
    * A `null` start means that the range extends indefinitely into the past and a `null` end means
    * that it extends indefinitely into the future.
    */

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -147,4 +147,5 @@ config:
     CanceledTripsSummaryPattern: org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryPattern#CanceledTripsSummaryPattern
     CanceledTripsSummaryRoute: org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryRoute#CanceledTripsSummaryRoute
     Notice: org.opentripplanner.transit.model.basic.Notice
+    OpenEndedOffsetDateTimeRange: org.opentripplanner.apis.gtfs.model.OpenEndedOffsetDateTimeRange#OpenEndedOffsetDateTimeRange
     RealTimeTripState: org.opentripplanner.apis.gtfs.model.RealTimeTripStateModel#RealTimeTripStateModel

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/generated/graphql-codegen.yml
@@ -147,5 +147,5 @@ config:
     CanceledTripsSummaryPattern: org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryPattern#CanceledTripsSummaryPattern
     CanceledTripsSummaryRoute: org.opentripplanner.apis.gtfs.model.CanceledTripsSummaryRoute#CanceledTripsSummaryRoute
     Notice: org.opentripplanner.transit.model.basic.Notice
-    OpenEndedOffsetDateTimeRange: org.opentripplanner.apis.gtfs.model.OpenEndedOffsetDateTimeRange#OpenEndedOffsetDateTimeRange
+    OffsetDateTimeRange: org.opentripplanner.apis.gtfs.model.OffsetDateTimeRange#OffsetDateTimeRange
     RealTimeTripState: org.opentripplanner.apis.gtfs.model.RealTimeTripStateModel#RealTimeTripStateModel

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/StreetNoteMapper.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/mapping/StreetNoteMapper.java
@@ -24,6 +24,9 @@ public class StreetNoteMapper {
           TimePeriod.of(note.effectiveStartDate.toInstant(), note.effectiveEndDate.toInstant())
         )
       );
+    } else {
+      // A note without a validity period is always active.
+      alert.withCalendar(AlertCalendar.ofAlwaysActive());
     }
     return alert.build();
   }

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRange.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRange.java
@@ -7,20 +7,21 @@ import javax.annotation.Nullable;
 import org.opentripplanner.core.model.time.TimePeriod;
 
 /**
- * A half-open range of time {@code [start, end)} where both bounds are optional.
+ * A range of time with inclusive start and exclusive end {@code [start, end)}. Both bounds are
+ * optional.
  * <p>
  * A {@code null} start means that the range extends indefinitely into the past and a {@code null}
  * end means that it extends indefinitely into the future.
  * <p>
  * This is a general purpose API model which is not tied to any specific domain concept, so it can
- * be used whenever an open-ended range of instants needs to be returned by the GTFS GraphQL API.
+ * be used whenever an unbounded range of instants needs to be returned by the GTFS GraphQL API.
  * <p>
- * TODO we can consider using this for use cases where the range is not open-ended both directions.
+ * TODO we can consider using this for use cases where the range is always required to be bounded in one or both directions.
  */
 public record OffsetDateTimeRange(@Nullable OffsetDateTime start, @Nullable OffsetDateTime end) {
   /**
-   * Orders the ranges chronologically: ranges with an open start come first and ranges with an open
-   * end come last.
+   * Orders the ranges chronologically: ranges with an unbounded start come first and ranges with an
+   * unbounded end come last.
    */
   public static final Comparator<OffsetDateTimeRange> CHRONOLOGICAL_ORDER = Comparator.comparing(
     OffsetDateTimeRange::start,

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRange.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRange.java
@@ -14,6 +14,8 @@ import org.opentripplanner.core.model.time.TimePeriod;
  * <p>
  * This is a general purpose API model which is not tied to any specific domain concept, so it can
  * be used whenever an open-ended range of instants needs to be returned by the GTFS GraphQL API.
+ * <p>
+ * TODO we can consider using this for use cases where the range is not open-ended both directions.
  */
 public record OffsetDateTimeRange(@Nullable OffsetDateTime start, @Nullable OffsetDateTime end) {
   /**

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRange.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRange.java
@@ -15,28 +15,21 @@ import org.opentripplanner.core.model.time.TimePeriod;
  * This is a general purpose API model which is not tied to any specific domain concept, so it can
  * be used whenever an open-ended range of instants needs to be returned by the GTFS GraphQL API.
  */
-public record OpenEndedOffsetDateTimeRange(
-  @Nullable OffsetDateTime start,
-  @Nullable OffsetDateTime end
-) {
+public record OffsetDateTimeRange(@Nullable OffsetDateTime start, @Nullable OffsetDateTime end) {
   /**
    * Orders the ranges chronologically: ranges with an open start come first and ranges with an open
    * end come last.
    */
-  public static final Comparator<OpenEndedOffsetDateTimeRange> CHRONOLOGICAL_ORDER =
-    Comparator.comparing(
-      OpenEndedOffsetDateTimeRange::start,
-      Comparator.nullsFirst(Comparator.naturalOrder())
-    ).thenComparing(
-      OpenEndedOffsetDateTimeRange::end,
-      Comparator.nullsLast(Comparator.naturalOrder())
-    );
+  public static final Comparator<OffsetDateTimeRange> CHRONOLOGICAL_ORDER = Comparator.comparing(
+    OffsetDateTimeRange::start,
+    Comparator.nullsFirst(Comparator.naturalOrder())
+  ).thenComparing(OffsetDateTimeRange::end, Comparator.nullsLast(Comparator.naturalOrder()));
 
   /**
    * Converts a {@link TimePeriod} into a range using the given time zone for the offsets.
    */
-  public static OpenEndedOffsetDateTimeRange of(TimePeriod period, ZoneId zoneId) {
-    return new OpenEndedOffsetDateTimeRange(
+  public static OffsetDateTimeRange of(TimePeriod period, ZoneId zoneId) {
+    return new OffsetDateTimeRange(
       period
         .start()
         .map(start -> OffsetDateTime.ofInstant(start, zoneId))

--- a/application/src/main/java/org/opentripplanner/apis/gtfs/model/OpenEndedOffsetDateTimeRange.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/model/OpenEndedOffsetDateTimeRange.java
@@ -1,0 +1,50 @@
+package org.opentripplanner.apis.gtfs.model;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Comparator;
+import javax.annotation.Nullable;
+import org.opentripplanner.core.model.time.TimePeriod;
+
+/**
+ * A half-open range of time {@code [start, end)} where both bounds are optional.
+ * <p>
+ * A {@code null} start means that the range extends indefinitely into the past and a {@code null}
+ * end means that it extends indefinitely into the future.
+ * <p>
+ * This is a general purpose API model which is not tied to any specific domain concept, so it can
+ * be used whenever an open-ended range of instants needs to be returned by the GTFS GraphQL API.
+ */
+public record OpenEndedOffsetDateTimeRange(
+  @Nullable OffsetDateTime start,
+  @Nullable OffsetDateTime end
+) {
+  /**
+   * Orders the ranges chronologically: ranges with an open start come first and ranges with an open
+   * end come last.
+   */
+  public static final Comparator<OpenEndedOffsetDateTimeRange> CHRONOLOGICAL_ORDER =
+    Comparator.comparing(
+      OpenEndedOffsetDateTimeRange::start,
+      Comparator.nullsFirst(Comparator.naturalOrder())
+    ).thenComparing(
+      OpenEndedOffsetDateTimeRange::end,
+      Comparator.nullsLast(Comparator.naturalOrder())
+    );
+
+  /**
+   * Converts a {@link TimePeriod} into a range using the given time zone for the offsets.
+   */
+  public static OpenEndedOffsetDateTimeRange of(TimePeriod period, ZoneId zoneId) {
+    return new OpenEndedOffsetDateTimeRange(
+      period
+        .start()
+        .map(start -> OffsetDateTime.ofInstant(start, zoneId))
+        .orElse(null),
+      period
+        .end()
+        .map(end -> OffsetDateTime.ofInstant(end, zoneId))
+        .orElse(null)
+    );
+  }
+}

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/ValidityPeriodType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/ValidityPeriodType.java
@@ -14,7 +14,7 @@ public class ValidityPeriodType {
         GraphQLFieldDefinition.newFieldDefinition()
           .name("startTime")
           .type(dateTimeScalar)
-          .description("Start of validity period")
+          .description("Start of validity period. Will return 'null' if validity is open-ended.")
           .dataFetcher(environment -> {
             ValidityPeriod period = environment.getSource();
             return period != null ? period.startTime() : null;

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/ValidityPeriodType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/framework/ValidityPeriodType.java
@@ -14,7 +14,9 @@ public class ValidityPeriodType {
         GraphQLFieldDefinition.newFieldDefinition()
           .name("startTime")
           .type(dateTimeScalar)
-          .description("Start of validity period. Will return 'null' if validity is open-ended.")
+          .description(
+            "The inclusive start of the validity period. Will return 'null' if the validity has an unbounded start."
+          )
           .dataFetcher(environment -> {
             ValidityPeriod period = environment.getSource();
             return period != null ? period.startTime() : null;
@@ -25,7 +27,9 @@ public class ValidityPeriodType {
         GraphQLFieldDefinition.newFieldDefinition()
           .name("endTime")
           .type(dateTimeScalar)
-          .description("End of validity period. Will return 'null' if validity is open-ended.")
+          .description(
+            "The exclusive end of the validity period. Will return 'null' if the validity has an unbounded end."
+          )
           .dataFetcher(environment -> {
             ValidityPeriod period = environment.getSource();
             return period != null ? period.endTime() : null;

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/PtSituationElementType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/PtSituationElementType.java
@@ -252,7 +252,7 @@ public class PtSituationElementType {
           .name("validityPeriods")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(validityPeriodType))))
           .description(
-            "The validity periods this situation is in effect, sorted in chronological order. " +
+            "The periods in which this situation is valid, sorted in chronological order. " +
               "There is always at least one period."
           )
           .dataFetcher(environment -> {

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/PtSituationElementType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/PtSituationElementType.java
@@ -252,7 +252,8 @@ public class PtSituationElementType {
           .name("validityPeriods")
           .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(validityPeriodType))))
           .description(
-            "The validity periods this situation is in effect, sorted in chronological order."
+            "The validity periods this situation is in effect, sorted in chronological order. " +
+              "There is always at least one period."
           )
           .dataFetcher(environment -> {
             TransitAlert alert = environment.getSource();

--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/PtSituationElementType.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/siri/sx/PtSituationElementType.java
@@ -12,7 +12,9 @@ import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLTypeReference;
+import java.time.Instant;
 import java.util.AbstractMap;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -231,6 +233,7 @@ public class PtSituationElementType {
         GraphQLFieldDefinition.newFieldDefinition()
           .name("validityPeriod")
           .type(validityPeriodType)
+          .deprecate("Use validityPeriods instead")
           .description("Period this situation is in effect")
           .dataFetcher(environment -> {
             TransitAlert alert = environment.getSource();
@@ -241,6 +244,38 @@ public class PtSituationElementType {
               ? alert.getEffectiveEndDate().toEpochMilli()
               : null;
             return new ValidityPeriod(startTime, endTime);
+          })
+          .build()
+      )
+      .field(
+        GraphQLFieldDefinition.newFieldDefinition()
+          .name("validityPeriods")
+          .type(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(validityPeriodType))))
+          .description(
+            "The validity periods this situation is in effect, sorted in chronological order."
+          )
+          .dataFetcher(environment -> {
+            TransitAlert alert = environment.getSource();
+            return alert
+              .calendar()
+              .timePeriods()
+              .stream()
+              .map(period ->
+                new ValidityPeriod(
+                  period.start().map(Instant::toEpochMilli).orElse(null),
+                  period.end().map(Instant::toEpochMilli).orElse(null)
+                )
+              )
+              .sorted(
+                Comparator.comparing(
+                  ValidityPeriod::startTime,
+                  Comparator.nullsFirst(Comparator.naturalOrder())
+                ).thenComparing(
+                  ValidityPeriod::endTime,
+                  Comparator.nullsLast(Comparator.naturalOrder())
+                )
+              )
+              .toList();
           })
           .build()
       )

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertCalendar.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertCalendar.java
@@ -11,7 +11,7 @@ import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 /**
  * The validity of an alert, expressed as a non-empty set of {@link TimePeriod}s. The alert is valid
- * if any of the periods is valid. An alert always has at least one period: if the source data does
+ * if any of the periods are valid. An alert always has at least one period: if the source data does
  * not contain any validity information, the alert is {@link #ofAlwaysActive() always active}.
  */
 public final class AlertCalendar {

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertCalendar.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertCalendar.java
@@ -66,10 +66,10 @@ public final class AlertCalendar {
   }
 
   /**
-   * The earliest start of all time periods, or empty if any period has an open start.
+   * The earliest start of all time periods, or empty if any period has an unbounded start.
    */
   public Optional<Instant> effectiveStart() {
-    if (timePeriods.stream().anyMatch(TimePeriod::hasOpenStart)) {
+    if (timePeriods.stream().anyMatch(TimePeriod::hasUnboundedStart)) {
       return Optional.empty();
     }
     return timePeriods
@@ -80,10 +80,10 @@ public final class AlertCalendar {
   }
 
   /**
-   * The latest end of all time periods, or empty if any period is open-ended.
+   * The latest end of all time periods, or empty if any period has an unbounded end.
    */
   public Optional<Instant> effectiveEnd() {
-    if (timePeriods.stream().anyMatch(TimePeriod::hasOpenEnd)) {
+    if (timePeriods.stream().anyMatch(TimePeriod::hasUnboundedEnd)) {
       return Optional.empty();
     }
     return timePeriods

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertCalendar.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/AlertCalendar.java
@@ -10,12 +10,12 @@ import org.opentripplanner.core.model.time.TimePeriod;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 /**
- * The validity of an alert, expressed as a set of {@link TimePeriod}s. The alert is valid if any of
- * the periods is valid, which means that an empty calendar is never valid.
+ * The validity of an alert, expressed as a non-empty set of {@link TimePeriod}s. The alert is valid
+ * if any of the periods is valid. An alert always has at least one period: if the source data does
+ * not contain any validity information, the alert is {@link #ofAlwaysActive() always active}.
  */
 public final class AlertCalendar {
 
-  private static final AlertCalendar NEVER_ACTIVE = new AlertCalendar(List.of());
   private static final AlertCalendar ALWAYS_ACTIVE = new AlertCalendar(
     List.of(TimePeriod.ofUnbounded())
   );
@@ -27,7 +27,13 @@ public final class AlertCalendar {
   }
 
   public static AlertCalendar of(Collection<TimePeriod> timePeriods) {
-    return timePeriods.isEmpty() ? NEVER_ACTIVE : new AlertCalendar(timePeriods);
+    if (timePeriods.isEmpty()) {
+      throw new IllegalArgumentException(
+        "An alert calendar must have at least one time period. Use ofAlwaysActive() if the alert " +
+          "has no validity information."
+      );
+    }
+    return new AlertCalendar(timePeriods);
   }
 
   public static AlertCalendar of(TimePeriod... timePeriods) {
@@ -41,19 +47,8 @@ public final class AlertCalendar {
     return ALWAYS_ACTIVE;
   }
 
-  /**
-   * A calendar without any time periods, which is never valid.
-   */
-  public static AlertCalendar ofNeverActive() {
-    return NEVER_ACTIVE;
-  }
-
   public Collection<TimePeriod> timePeriods() {
     return timePeriods;
-  }
-
-  public boolean isNeverActive() {
-    return timePeriods.isEmpty();
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlert.java
@@ -185,7 +185,7 @@ public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAle
   /**
    * Finds the first validity start from all timePeriods for this alert.
    *
-   * @return First start for this Alert, <code>null</code> if any period has an open start
+   * @return First start for this Alert, <code>null</code> if any period has an unbounded start
    */
   @Nullable
   public Instant getEffectiveStartDate() {
@@ -194,9 +194,9 @@ public class TransitAlert extends AbstractTransitEntity<TransitAlert, TransitAle
 
   /**
    * Finds the last validity end from all timePeriods for this alert. Returns <code>null</code>
-   * if the validity is open-ended
+   * if any period has an unbounded end.
    *
-   * @return Last end for this Alert, <code>null</code> if open-ended
+   * @return Last end for this Alert, <code>null</code> if any period has an unbounded end
    */
   @Nullable
   public Instant getEffectiveEndDate() {

--- a/application/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/alertpatch/TransitAlertBuilder.java
@@ -29,7 +29,8 @@ public class TransitAlertBuilder extends AbstractEntityBuilder<TransitAlert, Tra
   private String siriCodespace;
   private Integer version;
   private final Set<EntitySelector> entities = new HashSet<>();
-  private AlertCalendar calendar = AlertCalendar.ofNeverActive();
+  /** If the source data has no validity information, the alert is always active. */
+  private AlertCalendar calendar = AlertCalendar.ofAlwaysActive();
 
   TransitAlertBuilder(FeedScopedId id) {
     super(id);

--- a/application/src/main/java/org/opentripplanner/warmup/GtfsWarmupQueryExecutor.java
+++ b/application/src/main/java/org/opentripplanner/warmup/GtfsWarmupQueryExecutor.java
@@ -87,7 +87,7 @@ class GtfsWarmupQueryExecutor implements WarmupQueryStrategy {
               agency { gtfsId name }
               alerts {
                 alertHeaderText alertDescriptionText
-                effectiveStartDate effectiveEndDate
+                activityPeriods { start end }
                 alertSeverityLevel
               }
               pickupBookingInfo {

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -136,6 +136,12 @@ type Agency implements Node {
 "Alert of a current or upcoming disruption in public transportation"
 type Alert implements Node {
   """
+  The periods of time when this alert is active, sorted chronologically. An empty list means
+  that the alert is never active. A period without a start has always been active and a period
+  without an end is active indefinitely.
+  """
+  activityPeriods: [OpenEndedOffsetDateTimeRange!]!
+  """
   Agency affected by the disruption. Note that this value is present only if the
   disruption has an effect on all operations of the agency (e.g. in case of a strike).
   """
@@ -170,9 +176,9 @@ type Alert implements Node {
   "Url with more information in all different available languages"
   alertUrlTranslations: [TranslatedString!]! @deprecated(reason : "Use `alertUrl` instead. `accept-language` header can be used for translations or the `language` parameter on the `alertUrl` field.")
   "Time when this alert is not in effect anymore. Format: Unix timestamp in seconds"
-  effectiveEndDate: Long
+  effectiveEndDate: Long @deprecated(reason : "Use `activityPeriods` instead.")
   "Time when this alert comes into effect. Format: Unix timestamp in seconds"
-  effectiveStartDate: Long
+  effectiveStartDate: Long @deprecated(reason : "Use `activityPeriods` instead.")
   "Entities affected by the disruption."
   entities: [AlertEntity]
   "The feed in which this alert was published"
@@ -1061,6 +1067,20 @@ is known well ahead of time.
 type Notice {
   "Textual representation of the message"
   text: String
+}
+
+"""
+A range of time which can be open in either direction.
+
+The range is half-open, which means that the start is included in the range but the end is not.
+A `null` start means that the range extends indefinitely into the past and a `null` end means
+that it extends indefinitely into the future.
+"""
+type OpenEndedOffsetDateTimeRange {
+  "The exclusive end of the range or `null` if the range has no end."
+  end: OffsetDateTime
+  "The inclusive start of the range or `null` if the range has no start."
+  start: OffsetDateTime
 }
 
 type OpeningHours {

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -137,8 +137,9 @@ type Agency implements Node {
 type Alert implements Node {
   """
   The periods of time when this alert is active, sorted chronologically. There is always at
-  least one period. A period without a start has always been active and a period without an
-  end is active indefinitely.
+  least one period. Each period has an inclusive start and an exclusive end. A period with an
+  unbounded start has always been active and a period with an unbounded end is active
+  indefinitely.
   """
   activityPeriods: [OffsetDateTimeRange!]!
   """
@@ -1070,16 +1071,16 @@ type Notice {
 }
 
 """
-A range of time which can be open in either direction.
+A range of time which can be unbounded in either direction.
 
-The range is half-open, which means that the start is included in the range but the end is not.
+The start of the range is inclusive and the end is exclusive.
 A `null` start means that the range extends indefinitely into the past and a `null` end means
 that it extends indefinitely into the future.
 """
 type OffsetDateTimeRange {
-  "The exclusive end of the range or `null` if the range has no end."
+  "The exclusive end of the range or `null` if the range is unbounded in the future."
   end: OffsetDateTime
-  "The inclusive start of the range or `null` if the range has no start."
+  "The inclusive start of the range or `null` if the range is unbounded in the past."
   start: OffsetDateTime
 }
 

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -140,7 +140,7 @@ type Alert implements Node {
   least one period. A period without a start has always been active and a period without an
   end is active indefinitely.
   """
-  activityPeriods: [OpenEndedOffsetDateTimeRange!]!
+  activityPeriods: [OffsetDateTimeRange!]!
   """
   Agency affected by the disruption. Note that this value is present only if the
   disruption has an effect on all operations of the agency (e.g. in case of a strike).
@@ -1076,7 +1076,7 @@ The range is half-open, which means that the start is included in the range but 
 A `null` start means that the range extends indefinitely into the past and a `null` end means
 that it extends indefinitely into the future.
 """
-type OpenEndedOffsetDateTimeRange {
+type OffsetDateTimeRange {
   "The exclusive end of the range or `null` if the range has no end."
   end: OffsetDateTime
   "The inclusive start of the range or `null` if the range has no start."

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -136,9 +136,9 @@ type Agency implements Node {
 "Alert of a current or upcoming disruption in public transportation"
 type Alert implements Node {
   """
-  The periods of time when this alert is active, sorted chronologically. An empty list means
-  that the alert is never active. A period without a start has always been active and a period
-  without an end is active indefinitely.
+  The periods of time when this alert is active, sorted chronologically. There is always at
+  least one period. A period without a start has always been active and a period without an
+  end is active indefinitely.
   """
   activityPeriods: [OpenEndedOffsetDateTimeRange!]!
   """

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -606,7 +606,7 @@ type PtSituationElement {
   summary: [MultilingualString!]!
   "Period this situation is in effect"
   validityPeriod: ValidityPeriod @deprecated(reason : "Use validityPeriods instead")
-  "The validity periods this situation is in effect, sorted in chronological order. There is always at least one period."
+  "The periods in which this situation is valid, sorted in chronological order. There is always at least one period."
   validityPeriods: [ValidityPeriod!]!
   "Operator's version number for the situation element."
   version: Int

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -1637,9 +1637,9 @@ type TripSearchData {
 }
 
 type ValidityPeriod {
-  "End of validity period. Will return 'null' if validity is open-ended."
+  "The exclusive end of the validity period. Will return 'null' if the validity has an unbounded end."
   endTime: DateTime
-  "Start of validity period. Will return 'null' if validity is open-ended."
+  "The inclusive start of the validity period. Will return 'null' if the validity has an unbounded start."
   startTime: DateTime
 }
 

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -606,7 +606,7 @@ type PtSituationElement {
   summary: [MultilingualString!]!
   "Period this situation is in effect"
   validityPeriod: ValidityPeriod @deprecated(reason : "Use validityPeriods instead")
-  "The validity periods this situation is in effect, sorted in chronological order."
+  "The validity periods this situation is in effect, sorted in chronological order. There is always at least one period."
   validityPeriods: [ValidityPeriod!]!
   "Operator's version number for the situation element."
   version: Int

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -605,7 +605,9 @@ type PtSituationElement {
   "Summary of situation in all different translations available"
   summary: [MultilingualString!]!
   "Period this situation is in effect"
-  validityPeriod: ValidityPeriod
+  validityPeriod: ValidityPeriod @deprecated(reason : "Use validityPeriods instead")
+  "The validity periods this situation is in effect, sorted in chronological order."
+  validityPeriods: [ValidityPeriod!]!
   "Operator's version number for the situation element."
   version: Int
   "Timestamp when the situation element was updated."
@@ -1637,7 +1639,7 @@ type TripSearchData {
 type ValidityPeriod {
   "End of validity period. Will return 'null' if validity is open-ended."
   endTime: DateTime
-  "Start of validity period"
+  "Start of validity period. Will return 'null' if validity is open-ended."
   startTime: DateTime
 }
 

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -473,6 +473,14 @@ class GraphQLIntegrationTest {
       .withDescriptionText(I18NString.of("This station is currently closed"))
       .withEffect(AlertEffect.NO_SERVICE)
       .addEntity(stationEntitySelector)
+      // deliberately unsorted and with open bounds to test the sorting of the activity periods
+      .withCalendar(
+        AlertCalendar.of(
+          TimePeriod.of(ALERT_END_TIME, null),
+          TimePeriod.of(ALERT_START_TIME, ALERT_END_TIME),
+          TimePeriod.of(null, ALERT_START_TIME)
+        )
+      )
       .build();
 
     // TODO - Use itineraryBuilder() here not build() and complete building the itinerary using

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/StreetNoteMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/mapping/StreetNoteMapperTest.java
@@ -3,11 +3,11 @@ package org.opentripplanner.apis.gtfs.mapping;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.routing.alertpatch.AlertCalendar;
 import org.opentripplanner.routing.alertpatch.TransitAlert;
 import org.opentripplanner.street.model.note.StreetNote;
 
@@ -45,7 +45,7 @@ class StreetNoteMapperTest {
     note.effectiveStartDate = null;
     note.effectiveEndDate = null;
     TransitAlert alert = StreetNoteMapper.mapStreetNoteToAlert(note);
-    assertEquals(Collections.emptyList(), alert.calendar().timePeriods());
+    assertEquals(AlertCalendar.ofAlwaysActive(), alert.calendar());
   }
 
   private static StreetNote note() {

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRangeTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRangeTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.time.TimePeriod;
 
-class OpenEndedOffsetDateTimeRangeTest {
+class OffsetDateTimeRangeTest {
 
   private static final ZoneId ZONE_ID = ZoneId.of("Europe/Berlin");
   private static final Instant START = OffsetDateTime.parse(
@@ -19,7 +19,7 @@ class OpenEndedOffsetDateTimeRangeTest {
 
   @Test
   void convertBoundedPeriod() {
-    var subject = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(START, END), ZONE_ID);
+    var subject = OffsetDateTimeRange.of(TimePeriod.of(START, END), ZONE_ID);
 
     assertThat(subject.start()).isEqualTo(OffsetDateTime.parse("2023-02-15T12:03:28+01:00"));
     assertThat(subject.end()).isEqualTo(OffsetDateTime.parse("2023-02-16T12:03:28+01:00"));
@@ -27,7 +27,7 @@ class OpenEndedOffsetDateTimeRangeTest {
 
   @Test
   void convertUnboundedPeriod() {
-    var subject = OpenEndedOffsetDateTimeRange.of(TimePeriod.ofUnbounded(), ZONE_ID);
+    var subject = OffsetDateTimeRange.of(TimePeriod.ofUnbounded(), ZONE_ID);
 
     assertThat(subject.start()).isNull();
     assertThat(subject.end()).isNull();
@@ -35,14 +35,14 @@ class OpenEndedOffsetDateTimeRangeTest {
 
   @Test
   void sortChronologically() {
-    var openStart = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(null, START), ZONE_ID);
-    var bounded = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(START, END), ZONE_ID);
-    var openEndFromStart = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(START, null), ZONE_ID);
-    var openEnd = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(END, null), ZONE_ID);
+    var openStart = OffsetDateTimeRange.of(TimePeriod.of(null, START), ZONE_ID);
+    var bounded = OffsetDateTimeRange.of(TimePeriod.of(START, END), ZONE_ID);
+    var openEndFromStart = OffsetDateTimeRange.of(TimePeriod.of(START, null), ZONE_ID);
+    var openEnd = OffsetDateTimeRange.of(TimePeriod.of(END, null), ZONE_ID);
 
     var sorted = List.of(openEnd, bounded, openEndFromStart, openStart)
       .stream()
-      .sorted(OpenEndedOffsetDateTimeRange.CHRONOLOGICAL_ORDER)
+      .sorted(OffsetDateTimeRange.CHRONOLOGICAL_ORDER)
       .toList();
 
     assertThat(sorted).containsExactly(openStart, bounded, openEndFromStart, openEnd).inOrder();

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRangeTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/model/OffsetDateTimeRangeTest.java
@@ -35,16 +35,18 @@ class OffsetDateTimeRangeTest {
 
   @Test
   void sortChronologically() {
-    var openStart = OffsetDateTimeRange.of(TimePeriod.of(null, START), ZONE_ID);
+    var unboundedStart = OffsetDateTimeRange.of(TimePeriod.of(null, START), ZONE_ID);
     var bounded = OffsetDateTimeRange.of(TimePeriod.of(START, END), ZONE_ID);
-    var openEndFromStart = OffsetDateTimeRange.of(TimePeriod.of(START, null), ZONE_ID);
-    var openEnd = OffsetDateTimeRange.of(TimePeriod.of(END, null), ZONE_ID);
+    var unboundedEndFromStart = OffsetDateTimeRange.of(TimePeriod.of(START, null), ZONE_ID);
+    var unboundedEnd = OffsetDateTimeRange.of(TimePeriod.of(END, null), ZONE_ID);
 
-    var sorted = List.of(openEnd, bounded, openEndFromStart, openStart)
+    var sorted = List.of(unboundedEnd, bounded, unboundedEndFromStart, unboundedStart)
       .stream()
       .sorted(OffsetDateTimeRange.CHRONOLOGICAL_ORDER)
       .toList();
 
-    assertThat(sorted).containsExactly(openStart, bounded, openEndFromStart, openEnd).inOrder();
+    assertThat(sorted)
+      .containsExactly(unboundedStart, bounded, unboundedEndFromStart, unboundedEnd)
+      .inOrder();
   }
 }

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/model/OpenEndedOffsetDateTimeRangeTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/model/OpenEndedOffsetDateTimeRangeTest.java
@@ -1,0 +1,50 @@
+package org.opentripplanner.apis.gtfs.model;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opentripplanner.core.model.time.TimePeriod;
+
+class OpenEndedOffsetDateTimeRangeTest {
+
+  private static final ZoneId ZONE_ID = ZoneId.of("Europe/Berlin");
+  private static final Instant START = OffsetDateTime.parse(
+    "2023-02-15T12:03:28+01:00"
+  ).toInstant();
+  private static final Instant END = OffsetDateTime.parse("2023-02-16T12:03:28+01:00").toInstant();
+
+  @Test
+  void convertBoundedPeriod() {
+    var subject = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(START, END), ZONE_ID);
+
+    assertThat(subject.start()).isEqualTo(OffsetDateTime.parse("2023-02-15T12:03:28+01:00"));
+    assertThat(subject.end()).isEqualTo(OffsetDateTime.parse("2023-02-16T12:03:28+01:00"));
+  }
+
+  @Test
+  void convertUnboundedPeriod() {
+    var subject = OpenEndedOffsetDateTimeRange.of(TimePeriod.ofUnbounded(), ZONE_ID);
+
+    assertThat(subject.start()).isNull();
+    assertThat(subject.end()).isNull();
+  }
+
+  @Test
+  void sortChronologically() {
+    var openStart = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(null, START), ZONE_ID);
+    var bounded = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(START, END), ZONE_ID);
+    var openEndFromStart = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(START, null), ZONE_ID);
+    var openEnd = OpenEndedOffsetDateTimeRange.of(TimePeriod.of(END, null), ZONE_ID);
+
+    var sorted = List.of(openEnd, bounded, openEndFromStart, openStart)
+      .stream()
+      .sorted(OpenEndedOffsetDateTimeRange.CHRONOLOGICAL_ORDER)
+      .toList();
+
+    assertThat(sorted).containsExactly(openStart, bounded, openEndFromStart, openEnd).inOrder();
+  }
+}

--- a/application/src/test/java/org/opentripplanner/routing/alertpatch/AlertCalendarTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/alertpatch/AlertCalendarTest.java
@@ -1,9 +1,9 @@
 package org.opentripplanner.routing.alertpatch;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.List;
@@ -18,25 +18,14 @@ class AlertCalendarTest {
   private static final Instant LATER_END = Instant.parse("2024-01-02T12:00:00Z");
 
   @Test
-  void neverActive() {
-    var subject = AlertCalendar.ofNeverActive();
-    assertTrue(subject.isNeverActive());
-    assertThat(subject.timePeriods()).isEmpty();
-    assertFalse(subject.isActiveDuring(TimePeriod.of(START, END)));
-    assertThat(subject.effectiveStart()).isEmpty();
-    assertThat(subject.effectiveEnd()).isEmpty();
-  }
-
-  @Test
-  void ofEmptyCollectionIsNeverActive() {
-    assertEquals(AlertCalendar.ofNeverActive(), AlertCalendar.of(List.of()));
+  void ofEmptyCollectionIsRejected() {
+    assertThrows(IllegalArgumentException.class, () -> AlertCalendar.of(List.of()));
   }
 
   @Test
   void ofAlwaysActive() {
     var subject = AlertCalendar.ofAlwaysActive();
     assertThat(subject.timePeriods()).containsExactly(TimePeriod.ofUnbounded());
-    assertFalse(subject.isNeverActive());
     assertTrue(subject.isActiveDuring(TimePeriod.of(START, END)));
     assertThat(subject.effectiveStart()).isEmpty();
     assertThat(subject.effectiveEnd()).isEmpty();

--- a/application/src/test/java/org/opentripplanner/routing/alertpatch/AlertCalendarTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/alertpatch/AlertCalendarTest.java
@@ -41,7 +41,7 @@ class AlertCalendarTest {
   }
 
   @Test
-  void openStartGivesNoEffectiveStart() {
+  void unboundedStartGivesNoEffectiveStart() {
     var subject = AlertCalendar.of(
       List.of(TimePeriod.of(null, END), TimePeriod.of(LATER_START, LATER_END))
     );
@@ -50,7 +50,7 @@ class AlertCalendarTest {
   }
 
   @Test
-  void openEndGivesNoEffectiveEnd() {
+  void unboundedEndGivesNoEffectiveEnd() {
     var subject = AlertCalendar.of(
       List.of(TimePeriod.of(START, END), TimePeriod.of(LATER_START, null))
     );

--- a/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/alert/siri/SiriAlertsUpdateHandlerTest.java
@@ -891,7 +891,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
   }
 
   @Test
-  public void testSiriSxWithOpenEndedValidity() {
+  public void testSiriSxWithUnboundedEndValidity() {
     assertTrue(transitAlertService.getAllAlerts().isEmpty());
 
     final String situationNumber = "TST:SituationNumber:1234";
@@ -910,7 +910,7 @@ public class SiriAlertsUpdateHandlerTest extends GtfsTest {
     period_1.setEndTime(ZonedDateTime.parse("2020-02-01T11:00:00+01:00"));
     ptSituation.getValidityPeriods().add(period_1);
 
-    // Add period with start-, but NO endtime - i.e. open-ended
+    // Add period with start-, but NO endtime - i.e. an unbounded end
     HalfOpenTimestampOutputRangeStructure period_2 = new HalfOpenTimestampOutputRangeStructure();
     period_2.setStartTime(ZonedDateTime.parse("2020-02-02T10:00:00+01:00"));
     period_2.setEndTime(null);

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/alerts.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/alerts.json
@@ -8,7 +8,10 @@
         "descriptionDefault": "",
         "descriptionDe": "",
         "urlDefault": null,
-        "urlDe": null
+        "urlDe": null,
+        "activityPeriods": [],
+        "effectiveStartDate": null,
+        "effectiveEndDate": null
       },
       {
         "id": "QWxlcnQ6Rjpuby1oZWFkZXI",
@@ -17,7 +20,10 @@
         "descriptionDefault": "Second string",
         "descriptionDe": "Zweite Zeichenabfolge",
         "urlDefault": null,
-        "urlDe": null
+        "urlDe": null,
+        "activityPeriods": [],
+        "effectiveStartDate": null,
+        "effectiveEndDate": null
       },
       {
         "id": "QWxlcnQ6Rjphbi1hbGVydA",
@@ -26,7 +32,15 @@
         "descriptionDefault": "A description",
         "descriptionDe": "A description",
         "urlDefault": "https://example.com",
-        "urlDe": "https://example.com"
+        "urlDe": "https://example.com",
+        "activityPeriods": [
+          {
+            "start": "2023-02-15T12:03:28+01:00",
+            "end": "2023-02-16T12:03:28+01:00"
+          }
+        ],
+        "effectiveStartDate": 1676459008,
+        "effectiveEndDate": 1676545408
       },
       {
         "id": "QWxlcnQ6Rjpuby1kZXNjcmlwdGlvbg",
@@ -35,7 +49,10 @@
         "descriptionDefault": "First string",
         "descriptionDe": "Erste Zeichenabfolge",
         "urlDefault": null,
-        "urlDe": null
+        "urlDe": null,
+        "activityPeriods": [],
+        "effectiveStartDate": null,
+        "effectiveEndDate": null
       },
       {
         "id": "QWxlcnQ6RjphLXN0YXRpb24tYWxlcnQ",
@@ -44,7 +61,23 @@
         "descriptionDefault": "This station is currently closed",
         "descriptionDe": "This station is currently closed",
         "urlDefault": null,
-        "urlDe": null
+        "urlDe": null,
+        "activityPeriods": [
+          {
+            "start": null,
+            "end": "2023-02-15T12:03:28+01:00"
+          },
+          {
+            "start": "2023-02-15T12:03:28+01:00",
+            "end": "2023-02-16T12:03:28+01:00"
+          },
+          {
+            "start": "2023-02-16T12:03:28+01:00",
+            "end": null
+          }
+        ],
+        "effectiveStartDate": null,
+        "effectiveEndDate": null
       }
     ]
   }

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/alerts.json
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/expectations/alerts.json
@@ -9,7 +9,12 @@
         "descriptionDe": "",
         "urlDefault": null,
         "urlDe": null,
-        "activityPeriods": [],
+        "activityPeriods": [
+          {
+            "start": null,
+            "end": null
+          }
+        ],
         "effectiveStartDate": null,
         "effectiveEndDate": null
       },
@@ -21,7 +26,12 @@
         "descriptionDe": "Zweite Zeichenabfolge",
         "urlDefault": null,
         "urlDe": null,
-        "activityPeriods": [],
+        "activityPeriods": [
+          {
+            "start": null,
+            "end": null
+          }
+        ],
         "effectiveStartDate": null,
         "effectiveEndDate": null
       },
@@ -50,7 +60,12 @@
         "descriptionDe": "Erste Zeichenabfolge",
         "urlDefault": null,
         "urlDe": null,
-        "activityPeriods": [],
+        "activityPeriods": [
+          {
+            "start": null,
+            "end": null
+          }
+        ],
         "effectiveStartDate": null,
         "effectiveEndDate": null
       },

--- a/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/alerts.graphql
+++ b/application/src/test/resources/org/opentripplanner/apis/gtfs/queries/alerts.graphql
@@ -7,5 +7,11 @@
     descriptionDe: alertDescriptionText(language: "de")
     urlDefault: alertUrl
     urlDe: alertUrl(language: "de")
+    activityPeriods {
+      start
+      end
+    }
+    effectiveStartDate
+    effectiveEndDate
   }
 }

--- a/domain-core/src/main/java/org/opentripplanner/core/model/time/TimePeriod.java
+++ b/domain-core/src/main/java/org/opentripplanner/core/model/time/TimePeriod.java
@@ -7,10 +7,10 @@ import javax.annotation.Nullable;
 import org.opentripplanner.utils.tostring.ToStringBuilder;
 
 /**
- * Represents a half-open period of time {@code [start, end)}.
+ * Represents a period of time with an inclusive start and an exclusive end {@code [start, end)}.
  * <p>
- * Both bounds are optional: a {@code null} start means that the period has always been valid, and a
- * {@code null} end means that it is valid indefinitely (open-ended).
+ * Both bounds are optional: a {@code null} start means that the period has always been valid
+ * (unbounded start), and a {@code null} end means that it is valid indefinitely (unbounded end).
  */
 public final class TimePeriod {
 
@@ -64,25 +64,25 @@ public final class TimePeriod {
   /**
    * Returns {@code true} if the period has no defined start, meaning it has always been valid.
    */
-  public boolean hasOpenStart() {
+  public boolean hasUnboundedStart() {
     return start == null;
   }
 
   /**
    * Returns {@code true} if the period has no defined end, meaning it is valid indefinitely.
    */
-  public boolean hasOpenEnd() {
+  public boolean hasUnboundedEnd() {
     return end == null;
   }
 
   /**
-   * Returns {@code true} if this period overlaps the given {@code other} period. Open bounds on
-   * either period are treated as extending indefinitely in that direction.
+   * Returns {@code true} if this period overlaps the given {@code other} period. Unbounded bounds
+   * on either period are treated as extending indefinitely in that direction.
    */
   public boolean overlaps(TimePeriod other) {
     return (
-      (hasOpenStart() || other.hasOpenEnd() || start.isBefore(other.end)) &&
-      (hasOpenEnd() || other.hasOpenStart() || other.start.isBefore(end))
+      (hasUnboundedStart() || other.hasUnboundedEnd() || start.isBefore(other.end)) &&
+      (hasUnboundedEnd() || other.hasUnboundedStart() || other.start.isBefore(end))
     );
   }
 
@@ -90,7 +90,10 @@ public final class TimePeriod {
    * Returns {@code true} if the {@code instant} is within this period.
    */
   public boolean contains(Instant instant) {
-    return ((hasOpenStart() || !instant.isBefore(start)) && (hasOpenEnd() || end.isAfter(instant)));
+    return (
+      (hasUnboundedStart() || !instant.isBefore(start)) &&
+      (hasUnboundedEnd() || end.isAfter(instant))
+    );
   }
 
   @Override

--- a/domain-core/src/test/java/org/opentripplanner/core/model/time/TimePeriodTest.java
+++ b/domain-core/src/test/java/org/opentripplanner/core/model/time/TimePeriodTest.java
@@ -18,8 +18,8 @@ class TimePeriodTest {
     var subject = TimePeriod.of(START, END);
     assertThat(subject.start()).hasValue(START);
     assertThat(subject.end()).hasValue(END);
-    assertFalse(subject.hasOpenStart());
-    assertFalse(subject.hasOpenEnd());
+    assertFalse(subject.hasUnboundedStart());
+    assertFalse(subject.hasUnboundedEnd());
   }
 
   @Test
@@ -27,22 +27,22 @@ class TimePeriodTest {
     var subject = TimePeriod.ofUnbounded();
     assertThat(subject.start()).isEmpty();
     assertThat(subject.end()).isEmpty();
-    assertTrue(subject.hasOpenStart());
-    assertTrue(subject.hasOpenEnd());
+    assertTrue(subject.hasUnboundedStart());
+    assertTrue(subject.hasUnboundedEnd());
   }
 
   @Test
-  void openStart() {
+  void unboundedStart() {
     var subject = TimePeriod.of(null, END);
-    assertTrue(subject.hasOpenStart());
-    assertFalse(subject.hasOpenEnd());
+    assertTrue(subject.hasUnboundedStart());
+    assertFalse(subject.hasUnboundedEnd());
   }
 
   @Test
-  void openEnd() {
+  void unboundedEnd() {
     var subject = TimePeriod.of(START, null);
-    assertFalse(subject.hasOpenStart());
-    assertTrue(subject.hasOpenEnd());
+    assertFalse(subject.hasUnboundedStart());
+    assertTrue(subject.hasUnboundedEnd());
   }
 
   @Test
@@ -71,29 +71,29 @@ class TimePeriodTest {
   }
 
   @Test
-  void overlapsOpenStart() {
+  void overlapsUnboundedStart() {
     var subject = TimePeriod.of(null, END);
     assertTrue(subject.overlaps(TimePeriod.of(START.minusSeconds(2000), START.minusSeconds(1000))));
     assertFalse(subject.overlaps(TimePeriod.of(END.plusSeconds(100), END.plusSeconds(200))));
   }
 
   @Test
-  void overlapsOpenEnd() {
+  void overlapsUnboundedEnd() {
     var subject = TimePeriod.of(START, null);
     assertFalse(subject.overlaps(TimePeriod.of(START.minusSeconds(200), START.minusSeconds(100))));
     assertTrue(subject.overlaps(TimePeriod.of(END.plusSeconds(100), END.plusSeconds(200))));
   }
 
   @Test
-  void overlapsOpenBoundsOnOtherPeriod() {
+  void overlapsUnboundedBoundsOnOtherPeriod() {
     var subject = TimePeriod.of(START, END);
-    // other period is open-ended, starting before this period ends
+    // other period has an unbounded end, starting before this period ends
     assertTrue(subject.overlaps(TimePeriod.of(END.minusSeconds(100), null)));
-    // other period is open-ended, starting exactly at this period's end - exclusive
+    // other period has an unbounded end, starting exactly at this period's end - exclusive
     assertFalse(subject.overlaps(TimePeriod.of(END, null)));
-    // other period has an open start, ending after this period starts
+    // other period has an unbounded start, ending after this period starts
     assertTrue(subject.overlaps(TimePeriod.of(null, START.plusSeconds(1))));
-    // other period has an open start, ending exactly at this period's start. Because end
+    // other period has an unbounded start, ending exactly at this period's start. Because end
     // is exclusive, there is no overlap
     assertFalse(subject.overlaps(TimePeriod.of(null, START)));
     // other period is entirely unbounded
@@ -125,10 +125,10 @@ class TimePeriodTest {
   }
 
   @Test
-  void containsOpenStart() {
+  void containsUnboundedStart() {
     var subject = TimePeriod.of(null, END);
 
-    // far in the past is contained because the start is open
+    // far in the past is contained because the start is unbounded
     assertTrue(subject.contains(Instant.EPOCH));
     assertTrue(subject.contains(START));
     // exactly at the end - exclusive
@@ -137,14 +137,14 @@ class TimePeriodTest {
   }
 
   @Test
-  void containsOpenEnd() {
+  void containsUnboundedEnd() {
     var subject = TimePeriod.of(START, null);
 
     // before the start
     assertFalse(subject.contains(START.minusSeconds(1)));
     // exactly at the start - inclusive
     assertTrue(subject.contains(START));
-    // far in the future is contained because the end is open
+    // far in the future is contained because the end is unbounded
     assertTrue(subject.contains(END.plusSeconds(1_000_000)));
   }
 

--- a/domain-core/src/test/java/org/opentripplanner/core/model/time/TimePeriodTest.java
+++ b/domain-core/src/test/java/org/opentripplanner/core/model/time/TimePeriodTest.java
@@ -2,8 +2,8 @@ package org.opentripplanner.core.model.time;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import org.junit.jupiter.api.Test;

--- a/domain-core/src/test/java/org/opentripplanner/core/model/time/TimePeriodTest.java
+++ b/domain-core/src/test/java/org/opentripplanner/core/model/time/TimePeriodTest.java
@@ -1,8 +1,8 @@
 package org.opentripplanner.core.model.time;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;


### PR DESCRIPTION
### Summary

Both the GTFS and the Transmodel API only exposed one active period for alert (which might have been active during a gap between real active periods). This pr exposes the actual active periods and deprecates the old fields.

### Issue

No issue. This was discussed in a meeting.

### Unit tests

Added tests

### Documentation

Schema documentation

### Changelog

From title
