### PR TITLE
State every debug style filter in MapLibre's expression syntax

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleBuilder.java
+++ b/application/src/main/java/org/opentripplanner/apis/vectortiles/model/StyleBuilder.java
@@ -34,6 +34,12 @@ public class StyleBuilder {
   private final Map<String, Object> layout = new LinkedHashMap<>();
   private final Map<String, Object> metadata = new LinkedHashMap<>();
   private final Map<String, Object> line = new LinkedHashMap<>();
+  /**
+   * The layer's filter, always in MapLibre's expression syntax, which reaches a property through
+   * {@code ["get", …]} rather than naming it directly as the legacy syntax does. The two cannot be
+   * mixed inside a single filter, and the debug client combines a filter of its own with the one
+   * sent from here, so every filter built by this class has to keep speaking that dialect.
+   */
   private List<?> filter = List.of();
 
   public static StyleBuilder ofId(String id) {
@@ -293,7 +299,7 @@ public class StyleBuilder {
    * Filter the entities by a boolean property.
    */
   public final StyleBuilder booleanFilter(String propertyName, boolean value) {
-    filter = List.of("==", propertyName, value);
+    filter = List.of("==", List.of("get", propertyName), value);
     return this;
   }
 
@@ -342,7 +348,7 @@ public class StyleBuilder {
 
   private StyleBuilder filterClasses(Class... classToFilter) {
     var clazzes = Arrays.stream(classToFilter).map(Class::getSimpleName).toList();
-    filter = new ArrayList<>(ListUtils.combine(List.of("in", "class"), clazzes));
+    filter = List.of("in", List.of("get", "class"), List.of("literal", clazzes));
     return this;
   }
 

--- a/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/vectortiles/DebugStyleSpecTest.java
@@ -1,12 +1,15 @@
 package org.opentripplanner.apis.vectortiles;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.opentripplanner.framework.io.FileUtils.readFile;
 import static org.opentripplanner.framework.io.FileUtils.writeFile;
 import static org.opentripplanner.test.support.JsonAssertions.assertEqualJson;
 import static org.opentripplanner.test.support.JsonAssertions.isEqualJson;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.opentripplanner.apis.vectortiles.model.StyleSpec;
 import org.opentripplanner.apis.vectortiles.model.TileSource.VectorSource;
 import org.opentripplanner.apis.vectortiles.model.VectorSourceLayer;
 import org.opentripplanner.framework.json.ObjectMappers;
@@ -22,6 +25,67 @@ class DebugStyleSpecTest {
    */
   @Test
   void spec() {
+    var json = ObjectMappers.ignoringExtraFields().valueToTree(buildSpec());
+    var file = RESOURCES.testResourceFile("style.json");
+    var expectation = readFile(file);
+    var newJson = JsonSupport.prettyPrint(json);
+    // Order of keys in a JSON object can randomly change so only write to file when necessary
+    if (!isEqualJson(expectation, json)) {
+      writeFile(file, newJson);
+    }
+    assertEqualJson(expectation, newJson);
+  }
+
+  /**
+   * The debug client narrows the rental layers to a set of networks by combining its own filter
+   * with the one the server sent. MapLibre does not allow the legacy filter syntax and the
+   * expression syntax to be mixed inside one filter, so the client can only do that as long as
+   * every layer here speaks the same dialect.
+   */
+  @Test
+  void allFiltersUseExpressionSyntax() {
+    var json = ObjectMappers.ignoringExtraFields().valueToTree(buildSpec());
+
+    for (JsonNode layer : json.path("layers")) {
+      var filter = layer.path("filter");
+      if (!filter.isMissingNode()) {
+        assertWithMessage("layer '%s' has a legacy filter: %s", layer.path("id").asText(), filter)
+          .that(isLegacyFilter(filter))
+          .isFalse();
+      }
+    }
+  }
+
+  /**
+   * A legacy filter names the property directly and compares it to literals, as in
+   * {@code ["in", "class", "StreetEdge"]}, so none of its arguments is itself an array. An
+   * expression reaches the property through {@code ["get", …]} and therefore always nests at least
+   * one array, whether the property is the left operand ({@code ["==", ["get", "isStairs"], true]})
+   * or the right one ({@code ["in", "no-drop-off", ["string", ["get", "zoneType"]]]}).
+   */
+  private static boolean isLegacyFilter(JsonNode filter) {
+    if (!filter.isArray() || filter.isEmpty()) {
+      return false;
+    }
+    // "all", "any" and "none" combine sub-filters in both dialects, so a legacy one can hide inside
+    var operator = filter.get(0).asText();
+    if (operator.equals("all") || operator.equals("any") || operator.equals("none")) {
+      for (int i = 1; i < filter.size(); i++) {
+        if (isLegacyFilter(filter.get(i))) {
+          return true;
+        }
+      }
+      return false;
+    }
+    for (int i = 1; i < filter.size(); i++) {
+      if (filter.get(i).isArray()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static StyleSpec buildSpec() {
     var vectorSource = new VectorSource("vectorSource", "https://example.com");
     var regularStops = new VectorSourceLayer(vectorSource, "stops");
     var areaStops = new VectorSourceLayer(vectorSource, "stops");
@@ -31,7 +95,7 @@ class DebugStyleSpecTest {
     var geofencingZones = new VectorSourceLayer(vectorSource, "geofencingZones");
     var rental = new VectorSourceLayer(vectorSource, "rental");
     var transfers = new VectorSourceLayer(vectorSource, "transfers");
-    var spec = DebugStyleSpec.build(
+    return DebugStyleSpec.build(
       regularStops,
       areaStops,
       groupStops,
@@ -43,15 +107,5 @@ class DebugStyleSpecTest {
       List.of(),
       List.of("tier", "voi")
     );
-
-    var json = ObjectMappers.ignoringExtraFields().valueToTree(spec);
-    var file = RESOURCES.testResourceFile("style.json");
-    var expectation = readFile(file);
-    var newJson = JsonSupport.prettyPrint(json);
-    // Order of keys in a JSON object can randomly change so only write to file when necessary
-    if (!isEqualJson(expectation, json)) {
-      writeFile(file, newJson);
-    }
-    assertEqualJson(expectation, newJson);
   }
 }

--- a/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
+++ b/application/src/test/resources/org/opentripplanner/apis/vectortiles/style.json
@@ -121,8 +121,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "VehicleRentalVehicle"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "VehicleRentalVehicle"
+          ]
+        ]
       ],
       "layout" : {
         "visibility" : "none"
@@ -170,8 +178,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "VehicleRentalStation"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "VehicleRentalStation"
+          ]
+        ]
       ],
       "layout" : {
         "visibility" : "none"
@@ -317,7 +333,10 @@
       },
       "filter" : [
         "==",
-        "wheelchairAccessible",
+        [
+          "get",
+          "wheelchairAccessible"
+        ],
         true
       ],
       "layout" : {
@@ -366,7 +385,10 @@
       },
       "filter" : [
         "==",
-        "wheelchairAccessible",
+        [
+          "get",
+          "wheelchairAccessible"
+        ],
         false
       ],
       "layout" : {
@@ -668,15 +690,23 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetEdge",
-        "EscalatorEdge",
-        "PathwayEdge",
-        "ElevatorHopEdge",
-        "ElevatorBoardEdge",
-        "ElevatorAlightEdge",
-        "TemporaryPartialStreetEdge",
-        "TemporaryFreeEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetEdge",
+            "EscalatorEdge",
+            "PathwayEdge",
+            "ElevatorHopEdge",
+            "ElevatorBoardEdge",
+            "ElevatorAlightEdge",
+            "TemporaryPartialStreetEdge",
+            "TemporaryFreeEdge"
+          ]
+        ]
       ],
       "layout" : {
         "symbol-placement" : "line-center",
@@ -795,8 +825,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetEdge"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -821,15 +859,23 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetEdge",
-        "EscalatorEdge",
-        "PathwayEdge",
-        "ElevatorHopEdge",
-        "ElevatorBoardEdge",
-        "ElevatorAlightEdge",
-        "TemporaryPartialStreetEdge",
-        "TemporaryFreeEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetEdge",
+            "EscalatorEdge",
+            "PathwayEdge",
+            "ElevatorHopEdge",
+            "ElevatorBoardEdge",
+            "ElevatorAlightEdge",
+            "TemporaryPartialStreetEdge",
+            "TemporaryFreeEdge"
+          ]
+        ]
       ],
       "layout" : {
         "symbol-placement" : "line-center",
@@ -948,8 +994,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetEdge"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -974,15 +1028,23 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetEdge",
-        "EscalatorEdge",
-        "PathwayEdge",
-        "ElevatorHopEdge",
-        "ElevatorBoardEdge",
-        "ElevatorAlightEdge",
-        "TemporaryPartialStreetEdge",
-        "TemporaryFreeEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetEdge",
+            "EscalatorEdge",
+            "PathwayEdge",
+            "ElevatorHopEdge",
+            "ElevatorBoardEdge",
+            "ElevatorAlightEdge",
+            "TemporaryPartialStreetEdge",
+            "TemporaryFreeEdge"
+          ]
+        ]
       ],
       "layout" : {
         "symbol-placement" : "line-center",
@@ -1309,15 +1371,23 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetEdge",
-        "EscalatorEdge",
-        "PathwayEdge",
-        "ElevatorHopEdge",
-        "ElevatorBoardEdge",
-        "ElevatorAlightEdge",
-        "TemporaryPartialStreetEdge",
-        "TemporaryFreeEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetEdge",
+            "EscalatorEdge",
+            "PathwayEdge",
+            "ElevatorHopEdge",
+            "ElevatorBoardEdge",
+            "ElevatorAlightEdge",
+            "TemporaryPartialStreetEdge",
+            "TemporaryFreeEdge"
+          ]
+        ]
       ],
       "layout" : {
         "symbol-placement" : "line-center",
@@ -1392,8 +1462,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "AreaEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "AreaEdge"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -1441,15 +1519,23 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetEdge",
-        "EscalatorEdge",
-        "PathwayEdge",
-        "ElevatorHopEdge",
-        "ElevatorBoardEdge",
-        "ElevatorAlightEdge",
-        "TemporaryPartialStreetEdge",
-        "TemporaryFreeEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetEdge",
+            "EscalatorEdge",
+            "PathwayEdge",
+            "ElevatorHopEdge",
+            "ElevatorBoardEdge",
+            "ElevatorAlightEdge",
+            "TemporaryPartialStreetEdge",
+            "TemporaryFreeEdge"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -1474,15 +1560,23 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetEdge",
-        "EscalatorEdge",
-        "PathwayEdge",
-        "ElevatorHopEdge",
-        "ElevatorBoardEdge",
-        "ElevatorAlightEdge",
-        "TemporaryPartialStreetEdge",
-        "TemporaryFreeEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetEdge",
+            "EscalatorEdge",
+            "PathwayEdge",
+            "ElevatorHopEdge",
+            "ElevatorBoardEdge",
+            "ElevatorAlightEdge",
+            "TemporaryPartialStreetEdge",
+            "TemporaryFreeEdge"
+          ]
+        ]
       ],
       "layout" : {
         "symbol-placement" : "line-center",
@@ -1552,13 +1646,21 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetTransitStopLink",
-        "StreetTransitEntranceLink",
-        "BoardingLocationToStopLink",
-        "StreetVehicleRentalLink",
-        "StreetVehicleParkingLink",
-        "StreetStationCentroidLink"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetTransitStopLink",
+            "StreetTransitEntranceLink",
+            "BoardingLocationToStopLink",
+            "StreetVehicleRentalLink",
+            "StreetVehicleParkingLink",
+            "StreetStationCentroidLink"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -1645,8 +1747,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "StreetEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "StreetEdge"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -1735,8 +1845,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "ElevatorHopEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "ElevatorHopEdge"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -1784,8 +1902,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "ElevatorBoardEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "ElevatorBoardEdge"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -1833,8 +1959,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "ElevatorAlightEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "ElevatorAlightEdge"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -1883,8 +2017,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "ElevatorHopVertex"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "ElevatorHopVertex"
+          ]
+        ]
       ],
       "layout" : {
         "visibility" : "none"
@@ -1932,8 +2074,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "OsmElevatorVertex"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "OsmElevatorVertex"
+          ]
+        ]
       ],
       "layout" : {
         "visibility" : "none"
@@ -1980,8 +2130,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "EscalatorEdge"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "EscalatorEdge"
+          ]
+        ]
       ],
       "layout" : {
         "line-cap" : "round",
@@ -2029,7 +2187,10 @@
       },
       "filter" : [
         "==",
-        "isStairs",
+        [
+          "get",
+          "isStairs"
+        ],
         true
       ],
       "layout" : {
@@ -2123,8 +2284,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "VehicleParkingEntranceVertex"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "VehicleParkingEntranceVertex"
+          ]
+        ]
       ],
       "layout" : {
         "visibility" : "none"
@@ -2172,8 +2341,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "BarrierVertex"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "BarrierVertex"
+          ]
+        ]
       ],
       "layout" : {
         "visibility" : "none"
@@ -2221,8 +2398,16 @@
       },
       "filter" : [
         "in",
-        "class",
-        "BarrierPassThroughVertex"
+        [
+          "get",
+          "class"
+        ],
+        [
+          "literal",
+          [
+            "BarrierPassThroughVertex"
+          ]
+        ]
       ],
       "layout" : {
         "visibility" : "none"

--- a/client/src/components/MapView/LayerControl.tsx
+++ b/client/src/components/MapView/LayerControl.tsx
@@ -10,22 +10,6 @@ interface Layer {
 /** The group whose layers can be narrowed to a set of vehicle rental networks. */
 const RENTAL_GROUP = 'Rental';
 
-/**
- * MapLibre's legacy filter syntax names the property directly, as in ["in", "class", "StreetEdge"],
- * where the expression syntax wraps it: ["in", ["get", "class"], ["literal", [...]]]. The debug
- * style uses both - the rental vehicle and station layers are class-filtered in the legacy form,
- * the geofencing zone layers use expressions - and the two cannot be mixed inside one filter.
- */
-function isLegacyFilter(filter: unknown): boolean {
-  return Array.isArray(filter) && filter[0] === 'in' && typeof filter[1] === 'string';
-}
-
-function networkFilter(serverFilter: unknown, networks: Set<string>): unknown[] {
-  return isLegacyFilter(serverFilter)
-    ? ['in', 'network', ...networks]
-    : ['in', ['get', 'network'], ['literal', [...networks]]];
-}
-
 interface LayerControlProps {
   mapRef: MapRef | null;
   position: ControlPosition; // not used in inline styling, but you might use it if you want
@@ -140,12 +124,13 @@ const LayerControl: React.FC<LayerControlProps> = ({ mapRef, setInteractiveLayer
         const serverFilter = serverFilters.current.get(layer.id);
 
         // setFilter replaces rather than merges, so the server's own filter - which selects the
-        // vehicle, station or zone type the layer draws - has to be reapplied alongside ours, in
-        // the same dialect: an expression cannot be combined with a legacy filter.
+        // vehicle, station or zone type the layer draws - has to be reapplied alongside ours. The
+        // debug style states every filter in MapLibre's expression syntax, so the two combine
+        // directly; a legacy filter could not be nested inside this one.
         const filter =
           networks.size === rentalNetworks.length
             ? serverFilter
-            : ['all', serverFilter, networkFilter(serverFilter, networks)];
+            : ['all', serverFilter, ['in', ['get', 'network'], ['literal', [...networks]]]];
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         mapInstance.setFilter(layer.id, filter as any);


### PR DESCRIPTION
### Summary

Follow-up to #7888, addressing
[this review comment](https://github.com/opentripplanner/OpenTripPlanner/pull/7888#discussion_r3783248756):
make the filter syntax consistent across all layers so the debug client no longer has to detect
which dialect it was given.

The debug style mixed MapLibre's two filter dialects. `StyleBuilder` emitted class filters in the
legacy form, `["in", "class", "StreetEdge"]`, and boolean filters likewise, `["==", "isStairs",
true]`, while the geofencing-zone and permission filters were already expressions. The two cannot be
mixed inside a single filter, and the client combines a network filter of its own with the one the
server sent — so it carried an `isLegacyFilter` check and built whichever dialect matched.

`StyleBuilder` now emits expressions throughout:

```java
// filterClasses
List.of("in", List.of("get", "class"), List.of("literal", clazzes))
// booleanFilter
List.of("==", List.of("get", propertyName), value)
```

The same features match as before — this is a syntax change, not a behaviour one — and the client
drops the detection, always building
`["all", serverFilter, ["in", ["get", "network"], ["literal", [...]]]]`.

Notes:

- `filterValueInProperty` is untouched. It is already an expression, but note that its `in` does
  *substring* matching against a string property (`"PEDESTRIAN"` inside `"PEDESTRIAN,BICYCLE"`),
  unlike the exact-match `in` over an array that the class filter now uses. Changing that would be a
  behaviour change, so it is out of scope here.
- The `==` conversion is null-safe in both dialects: `wheelchairAccessible` and `isStairs` are absent
  on non-street edges in the same source layer, and legacy `==` and `["==", ["get", …], …]` both
  evaluate to false there rather than erroring. `class` is emitted unconditionally by all four
  property mappers, so the `in` conversion has no null-needle case.

### Issue

No issue; this addresses a review comment on #7888 and the problem is described in full above.

related to #7888

### Unit tests

`DebugStyleSpecTest` gains `allFiltersUseExpressionSyntax`, which walks every layer in the built
style and fails on a legacy filter, so the dialect cannot drift back unnoticed. It fails against the
previous output, naming `rental-vehicle`. Detecting "legacy" needs a slightly subtler rule than
"names the property directly": `filterValueInProperty` emits `["in", "no-drop-off", ["string",
["get", "zoneType"]]]`, which also has a bare string in that position. The test instead treats a
filter as legacy when *none* of its arguments is an array — an expression always nests at least one,
whether the property is the left operand or the right — recursing through `all`/`any`/`none`.

`style.json` is regenerated. The client changes are covered by `tsc`, eslint and the existing client
tests.

Beyond that the style was exercised against a real graph: OTP running on an Oslo/Akershus street
graph with live Voi and Bolt GBFS feeds, driving the `rental-vehicle` layer through four filter
states and counting rendered features by their `network` property:

| filter | rendered | by network |
| --- | --- | --- |
| server filter only | 563 | boltoslo 353, voioslo 210 |
| `+ ["in", ["get","network"], ["literal", ["voioslo"]]]` | 210 | voioslo 210 |
| `+ ["in", ["get","network"], ["literal", ["boltoslo"]]]` | 353 | boltoslo 353 |
| `+ ["literal", []]` | 0 | — |

353 + 210 = 563, and each single-network state contains only that network. The `edge` layer (an
eight-class `in`) draws the full street network and nothing when switched off; `stairs-edge` (the
converted `==`) draws a sparse set of segments exactly where stairs are, not every street; and the
style loads with no MapLibre errors, which an invalid expression would produce.

### Documentation

Javadoc on the `filter` field in `StyleBuilder` records that every filter it builds must stay in
expression syntax, and why. The comment in the client that explained the dialect check is replaced
by a shorter one, since the thing it explained is gone. No configuration changes.