### PR TITLE
Only add stop connectivity graph build module, when both street and transit exists

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -186,9 +186,7 @@ public class GraphBuilder implements Runnable {
       graphBuilder.addModule(factory.graphCoherencyCheckerModule());
     }
 
-    if (graph.hasStreets && graphBuilder.hasTransitData()) {
-      graphBuilder.addModule(factory.stopConnectivityModule());
-    }
+    graphBuilder.addModule(factory.stopConnectivityModule());
 
     graphBuilder.addModuleOptional(factory.routeToCentroidStationIdValidator());
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -186,7 +186,9 @@ public class GraphBuilder implements Runnable {
       graphBuilder.addModule(factory.graphCoherencyCheckerModule());
     }
 
-    graphBuilder.addModule(factory.stopConnectivityModule());
+    if (graph.hasStreets && graphBuilder.hasTransitData()) {
+      graphBuilder.addModule(factory.stopConnectivityModule());
+    }
 
     graphBuilder.addModuleOptional(factory.routeToCentroidStationIdValidator());
 

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/stopconnectivity/StopConnectivityModule.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/stopconnectivity/StopConnectivityModule.java
@@ -36,6 +36,9 @@ public class StopConnectivityModule implements GraphBuilderModule {
 
   @Override
   public void buildGraph() {
+    if (!graph.hasStreets) {
+      return;
+    }
     var progress = ProgressTracker.track(
       "Stop connectivity analysis",
       5000,

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/stopconnectivity/StopConnectivityModuleTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/stopconnectivity/StopConnectivityModuleTest.java
@@ -31,6 +31,7 @@ class StopConnectivityModuleTest extends GraphRoutingTest {
     StreetModelForTest.streetEdge(i1, i3);
 
     var g = new Graph();
+    g.hasStreets = true;
     g.addVertex(stop);
     g.addVertex(i1);
     g.addVertex(i2);


### PR DESCRIPTION
This is a tiny bugfix: only run the stop connectivity module when both street and transit data is available.

Background: the Germany speed test checks the stop connectivity even though there is no OSM data that could be improved (which is the goal of this module).