### PR TITLE
Add missing carpool transit mode to the Transmodel API mode enum

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -497,6 +497,7 @@ public class EnumTypes {
     .value("trolleybus", TransitMode.TROLLEYBUS)
     .value("monorail", TransitMode.MONORAIL)
     .value("coach", TransitMode.COACH)
+    .value("carpool", TransitMode.CARPOOL)
     .value("unknown", "unknown")
     .build();
 

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -2070,6 +2070,7 @@ enum TransportMode {
   air
   bus
   cableway
+  carpool
   coach
   funicular
   lift

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/model/EnumTypesTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/model/EnumTypesTest.java
@@ -3,12 +3,16 @@ package org.opentripplanner.apis.transmodel.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.opentripplanner.apis.transmodel.model.EnumTypes.LEG_MODE;
 import static org.opentripplanner.apis.transmodel.model.EnumTypes.RELATIVE_DIRECTION;
 import static org.opentripplanner.apis.transmodel.model.EnumTypes.ROUTING_ERROR_CODE;
+import static org.opentripplanner.apis.transmodel.model.EnumTypes.TRANSPORT_MODE;
 import static org.opentripplanner.apis.transmodel.model.EnumTypes.map;
 
 import graphql.GraphQLContext;
+import graphql.schema.GraphQLEnumType;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
@@ -19,6 +23,7 @@ import org.opentripplanner.apis.transmodel.mapping.RelativeDirectionMapper;
 import org.opentripplanner.core.model.doc.DocumentedEnum;
 import org.opentripplanner.model.plan.walkstep.RelativeDirection;
 import org.opentripplanner.routing.api.response.RoutingErrorCode;
+import org.opentripplanner.transit.model.basic.TransitMode;
 
 class EnumTypesTest {
 
@@ -103,6 +108,24 @@ class EnumTypesTest {
         .toList()
     );
     assertEquals(expected, values);
+  }
+
+  /**
+   * Carpool lines reach the API from GTFS route types 1551-1560. Before this mapping existed the
+   * mode could not be serialized, and a single carpool line made any query selecting
+   * {@code transportMode} fail. The mode enums are not exhaustive over {@link TransitMode}, so this
+   * test guards the one mode rather than the whole set.
+   */
+  @Test
+  void assertCarpoolIsMappedInBothModeEnums() {
+    assertEquals(TransitMode.CARPOOL, mappedValue(TRANSPORT_MODE, "carpool"));
+    assertEquals(TransitMode.CARPOOL, mappedValue(LEG_MODE, "carpool"));
+  }
+
+  private static Object mappedValue(GraphQLEnumType type, String apiName) {
+    var value = type.getValue(apiName);
+    assertNotNull(value, () -> "'%s' is not mapped in enum %s".formatted(apiName, type.getName()));
+    return value.getValue();
   }
 
   private enum Foo implements DocumentedEnum<Foo> {


### PR DESCRIPTION
### Summary

Carpool lines are imported from GTFS route types 1551–1560 and mapped to
`TransitMode.CARPOOL`, but the Transmodel `TransportMode` enum could not express the value.

The effect was not a missing value but a failing query. One carpool line in the graph made
any query selecting `transportMode` return an error instead of data:

    Can't serialize value (/lines[147]/transportMode) :
    Invalid input for enum 'TransportMode'. Unknown value 'CARPOOL'

Because the error is raised during serialization of the field, the whole query result is
replaced by an `errors` block — it is not confined to the affected line. Filtering was hit
too, since `transportModes: [carpool]` was rejected at validation time. Ten fields in the
schema are typed `TransportMode` (two of them deprecated), including the trip query's mode
filters, so this was not limited to reading a line's mode.

The `Mode` enum already maps `carpool`, so only `TransportMode` needed the addition.
`schema.graphql` is regenerated by `TransmodelGraphQLSchemaTest`.

Scope note: `TransitMode` has other values that neither mode enum expresses. Those are left
alone here — `cableCar` in particular is deliberately not added, since it would be read as a
variant of the existing `cableway`.

### Unit tests

`EnumTypesTest.assertCarpoolIsMappedInBothModeEnums` asserts that `carpool` resolves to
`TransitMode.CARPOOL` in both `TransportMode` and `Mode`. A small helper turns a missing
mapping into a readable failure naming the enum.

The test was verified to have teeth: with `EnumTypes.java` reverted it fails with
`'carpool' is not mapped in enum TransportMode`.

Manual verification: built a graph containing a carpool route and confirmed that
`{ lines { id transportMode } }` returns the mode instead of a serialization error, and that
`lines(transportModes: [carpool])` now passes validation.

No performance implications — this is enum registration at schema build time.

### Documentation

No new configuration options. `schema.graphql` is regenerated, not hand-edited.