### PR TITLE
Fix flaky test `StreetEdgeSplittingTest.testSplitting`

### DIFF
--- a/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeSplittingTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/StreetEdgeSplittingTest.java
@@ -73,10 +73,14 @@ class StreetEdgeSplittingTest {
       var sp0 = s0.splitDestructively(sv0);
       var sp1 = s1.splitDestructively(sv1);
 
-      // distances expressed internally in mm so this epsilon is plenty good enough to ensure that they
-      // have the same values
-      assertEquals(sp0.head().getDistanceMeters(), sp1.tail().getDistanceMeters(), 0.0000001);
-      assertEquals(sp0.tail().getDistanceMeters(), sp1.head().getDistanceMeters(), 0.0000001);
+      // distances are expressed internally as whole millimeters, but the split fraction for the
+      // forward and back edges is computed independently from their (forward vs. reversed)
+      // geometries. SphericalDistanceLibrary.distance(a, b) is not perfectly bit-symmetric under
+      // swapping a and b, so the two independent millimeter roundings can occasionally differ by
+      // 1 mm (0.001 m). Use an epsilon slightly larger than that to avoid flakiness while still
+      // catching real regressions.
+      assertEquals(sp0.head().getDistanceMeters(), sp1.tail().getDistanceMeters(), 0.0011);
+      assertEquals(sp0.tail().getDistanceMeters(), sp1.head().getDistanceMeters(), 0.0011);
       assertFalse(sp0.head().isBack());
       assertFalse(sp0.tail().isBack());
       assertTrue(sp1.head().isBack());


### PR DESCRIPTION
### Summary

`StreetEdgeSplittingTest.testSplitting:78 expected: <62168.843> but was: <62168.844>`
https://github.com/opentripplanner/OpenTripPlanner/actions/runs/33068358178/job/98503996377?pr=7785

Claude did some testing and concluded this:

> Confirmed: distance(a,b) and distance(b,a) differ at the ~1e-10 level for nearly every point pair — this is the root cause of the mm-rounding mismatch (occasionally straddling an integer-mm boundary, producing a 1mm/0.001m discrepancy in split lengths). Now I'll write the plan.

### Issue

N/A

### Unit tests

- Fixed `StreetEdgeSplittingTest.testSplitting`

### Documentation

N/A