### PR TITLE
Fix GTFS GraphQL API's stop call's real-time estimated times

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/EstimatedTime.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/EstimatedTime.java
@@ -23,7 +23,7 @@ public class EstimatedTime {
 
   public static EstimatedTime of(ZonedDateTime scheduledTime, int delaySecs) {
     var delay = Duration.ofSeconds(delaySecs);
-    return new EstimatedTime(scheduledTime.minus(delay), delay);
+    return new EstimatedTime(scheduledTime.plus(delay), delay);
   }
 
   public ZonedDateTime time() {

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/EstimatedTimeTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/EstimatedTimeTest.java
@@ -1,0 +1,43 @@
+package org.opentripplanner.transit.model.timetable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+
+class EstimatedTimeTest {
+
+  private static final ZonedDateTime SCHEDULED = ZonedDateTime.of(
+    2025,
+    1,
+    15,
+    10,
+    0,
+    0,
+    0,
+    ZoneId.of("Europe/Helsinki")
+  );
+
+  @Test
+  void delayedVehicleIsLaterThanScheduled() {
+    var estimate = EstimatedTime.of(SCHEDULED, 120);
+    assertEquals(SCHEDULED.plusMinutes(2), estimate.time());
+    assertEquals(Duration.ofMinutes(2), estimate.delay());
+  }
+
+  @Test
+  void earlyVehicleIsEarlierThanScheduled() {
+    var estimate = EstimatedTime.of(SCHEDULED, -60);
+    assertEquals(SCHEDULED.minusMinutes(1), estimate.time());
+    assertEquals(Duration.ofMinutes(-1), estimate.delay());
+  }
+
+  @Test
+  void onTimeVehicle() {
+    var estimate = EstimatedTime.of(SCHEDULED, 0);
+    assertEquals(SCHEDULED, estimate.time());
+    assertEquals(Duration.ZERO, estimate.delay());
+  }
+}


### PR DESCRIPTION
### Summary

There was a simple bug in EstimatedTime's (used in the GTFS API) factory method which caused delay to be subtracted instead of added to times. This bug has been hidden for a while because the real-time capabilities of the new call type have not been relevant in the canceled calls.

### Issue

No issue

### Unit tests

Added tests

### Documentation

No

### Changelog

From title
