### PR TITLE
Support GML DirectPosition in NeTEx 

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/mapping/WgsCoordinateMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/WgsCoordinateMapper.java
@@ -21,11 +21,15 @@ class WgsCoordinateMapper {
     }
     LocationStructure loc = point.getLocation();
 
-    // This should not happen
-    if (loc.getLongitude() == null || loc.getLatitude() == null) {
+    if (loc.getLongitude() != null && loc.getLatitude() != null) {
+      return new WgsCoordinate(loc.getLatitude().doubleValue(), loc.getLongitude().doubleValue());
+    }
+    // seen in Italian NeTEx data
+    else if (loc.getPos() != null && loc.getPos().getValue().size() >= 2) {
+      var coordinates = loc.getPos().getValue();
+      return new WgsCoordinate(coordinates.getFirst(), coordinates.get(1));
+    } else {
       throw new IllegalArgumentException("Coordinate is not valid: " + loc);
     }
-    // Location is safe to process
-    return new WgsCoordinate(loc.getLatitude().doubleValue(), loc.getLongitude().doubleValue());
   }
 }

--- a/application/src/main/java/org/opentripplanner/netex/mapping/WgsCoordinateMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/WgsCoordinateMapper.java
@@ -1,6 +1,7 @@
 package org.opentripplanner.netex.mapping;
 
 import javax.annotation.Nullable;
+import net.opengis.gml._3.DirectPositionType;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.rutebanken.netex.model.LocationStructure;
 import org.rutebanken.netex.model.SimplePoint_VersionStructure;
@@ -8,11 +9,7 @@ import org.rutebanken.netex.model.SimplePoint_VersionStructure;
 class WgsCoordinateMapper {
 
   /**
-   * This utility method check if the given {@code point} or one of its sub elements is {@code null}
-   * before passing the location to the given {@code locationHandler}.
-   *
-   * @return true if the handler is successfully invoked with a location, {@code false} if any of
-   * the required data elements are {@code null}.
+   * Maps a NeTEx {@code SimplePoint_VersionStructure} to a {@code WgsCoordinate}.
    */
   @Nullable
   static WgsCoordinate mapToDomain(SimplePoint_VersionStructure point) {
@@ -21,12 +18,13 @@ class WgsCoordinateMapper {
     }
     LocationStructure loc = point.getLocation();
 
+    final DirectPositionType pos = loc.getPos();
     if (loc.getLongitude() != null && loc.getLatitude() != null) {
       return new WgsCoordinate(loc.getLatitude().doubleValue(), loc.getLongitude().doubleValue());
     }
     // seen in Italian NeTEx data
-    else if (loc.getPos() != null && loc.getPos().getValue().size() >= 2) {
-      var coordinates = loc.getPos().getValue();
+    else if (pos != null && (pos.getValue().size() == 2 || pos.getValue().size() == 3)) {
+      var coordinates = pos.getValue();
       return new WgsCoordinate(coordinates.getFirst(), coordinates.get(1));
     } else {
       throw new IllegalArgumentException("Coordinate is not valid: " + loc);

--- a/application/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
@@ -5,14 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
+import net.opengis.gml._3.DirectPositionType;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.rutebanken.netex.model.LocationStructure;
 import org.rutebanken.netex.model.SimplePoint_VersionStructure;
 
-public class WgsCoordinateMapperTest {
+class WgsCoordinateMapperTest {
 
-  private static final double DELTA = 0.01d;
+  private static final double EPSILON = 0.01d;
 
   private static final double LONGITUDE_VALUE = 62.8;
   private static final BigDecimal LONGITUDE = BigDecimal.valueOf(LONGITUDE_VALUE);
@@ -21,7 +22,7 @@ public class WgsCoordinateMapperTest {
   private static final BigDecimal LATITUDE = BigDecimal.valueOf(LATITUDE_VALUE);
 
   @Test
-  public void handleCoordinatesWithValuesSet() {
+  void handleCoordinatesWithValuesSet() {
     // Given a valid point
     final SimplePoint_VersionStructure point = new SimplePoint_VersionStructure().withLocation(
       new LocationStructure().withLongitude(LONGITUDE).withLatitude(LATITUDE)
@@ -31,23 +32,23 @@ public class WgsCoordinateMapperTest {
     WgsCoordinate c = WgsCoordinateMapper.mapToDomain(point);
 
     // Then verify coordinate
-    assertEquals(LONGITUDE_VALUE, c.longitude(), DELTA);
-    assertEquals(LATITUDE_VALUE, c.latitude(), DELTA);
+    assertEquals(LONGITUDE_VALUE, c.longitude(), EPSILON);
+    assertEquals(LATITUDE_VALUE, c.latitude(), EPSILON);
   }
 
   @Test
-  public void handleCoordinatesWithMissingPoint() {
+  void handleCoordinatesWithMissingPoint() {
     assertNull(WgsCoordinateMapper.mapToDomain(null));
   }
 
   @Test
-  public void handleCoordinatesWithMissingLocation() {
+  void handleCoordinatesWithMissingLocation() {
     SimplePoint_VersionStructure p = new SimplePoint_VersionStructure();
     assertNull(WgsCoordinateMapper.mapToDomain(p));
   }
 
   @Test
-  public void handleCoordinatesWithMissingLatitude() {
+  void handleCoordinatesWithMissingLatitude() {
     SimplePoint_VersionStructure p;
     p = new SimplePoint_VersionStructure().withLocation(
       new LocationStructure().withLongitude(LONGITUDE)
@@ -57,11 +58,24 @@ public class WgsCoordinateMapperTest {
   }
 
   @Test
-  public void handleCoordinatesWithMissingLongitude() {
+  void handleCoordinatesWithMissingLongitude() {
     SimplePoint_VersionStructure p;
     p = new SimplePoint_VersionStructure().withLocation(
       new LocationStructure().withLatitude(LATITUDE)
     );
     assertThrows(IllegalArgumentException.class, () -> WgsCoordinateMapper.mapToDomain(p));
+  }
+
+  @Test
+  void pos() {
+    SimplePoint_VersionStructure p;
+    p = new SimplePoint_VersionStructure().withLocation(
+      new LocationStructure().withPos(
+        new DirectPositionType().withValue(LATITUDE_VALUE, LONGITUDE_VALUE)
+      )
+    );
+    var coord = WgsCoordinateMapper.mapToDomain(p);
+    assertEquals(LATITUDE_VALUE, coord.latitude(), EPSILON);
+    assertEquals(LONGITUDE_VALUE, coord.longitude(), EPSILON);
   }
 }

--- a/application/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
@@ -67,7 +67,7 @@ class WgsCoordinateMapperTest {
   }
 
   @Test
-  void pos() {
+  void pos2Numbers() {
     SimplePoint_VersionStructure p;
     p = new SimplePoint_VersionStructure().withLocation(
       new LocationStructure().withPos(
@@ -77,5 +77,15 @@ class WgsCoordinateMapperTest {
     var coord = WgsCoordinateMapper.mapToDomain(p);
     assertEquals(LATITUDE_VALUE, coord.latitude(), EPSILON);
     assertEquals(LONGITUDE_VALUE, coord.longitude(), EPSILON);
+  }
+
+  @Test
+  void pos0Numbers() {
+    SimplePoint_VersionStructure p;
+    p = new SimplePoint_VersionStructure().withLocation(
+      new LocationStructure().withPos(new DirectPositionType())
+    );
+
+    assertThrows(IllegalArgumentException.class, () -> WgsCoordinateMapper.mapToDomain(p));
   }
 }

--- a/application/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/WgsCoordinateMapperTest.java
@@ -59,8 +59,7 @@ class WgsCoordinateMapperTest {
 
   @Test
   void handleCoordinatesWithMissingLongitude() {
-    SimplePoint_VersionStructure p;
-    p = new SimplePoint_VersionStructure().withLocation(
+    var p = new SimplePoint_VersionStructure().withLocation(
       new LocationStructure().withLatitude(LATITUDE)
     );
     assertThrows(IllegalArgumentException.class, () -> WgsCoordinateMapper.mapToDomain(p));
@@ -68,10 +67,23 @@ class WgsCoordinateMapperTest {
 
   @Test
   void pos2Numbers() {
+    var coord = WgsCoordinateMapper.mapToDomain(
+      new SimplePoint_VersionStructure().withLocation(
+        new LocationStructure().withPos(
+          new DirectPositionType().withValue(LATITUDE_VALUE, LONGITUDE_VALUE)
+        )
+      )
+    );
+    assertEquals(LATITUDE_VALUE, coord.latitude(), EPSILON);
+    assertEquals(LONGITUDE_VALUE, coord.longitude(), EPSILON);
+  }
+
+  @Test
+  void pos3Numbers() {
     SimplePoint_VersionStructure p;
     p = new SimplePoint_VersionStructure().withLocation(
       new LocationStructure().withPos(
-        new DirectPositionType().withValue(LATITUDE_VALUE, LONGITUDE_VALUE)
+        new DirectPositionType().withValue(LATITUDE_VALUE, LONGITUDE_VALUE, 100d)
       )
     );
     var coord = WgsCoordinateMapper.mapToDomain(p);
@@ -81,8 +93,7 @@ class WgsCoordinateMapperTest {
 
   @Test
   void pos0Numbers() {
-    SimplePoint_VersionStructure p;
-    p = new SimplePoint_VersionStructure().withLocation(
+    var p = new SimplePoint_VersionStructure().withLocation(
       new LocationStructure().withPos(new DirectPositionType())
     );
 


### PR DESCRIPTION
### Summary

Italian NeTEx data supplies StopPlace coordinates as a GML `DirectPosition`, not as lat/lon on the `LocationStructure`.

```xml
<StopPlace
	xmlns="http://www.netex.org.uk/netex"
	xmlns:ns2="http://www.opengis.net/gml/3.2"
	xmlns:ns3="http://www.siri.org.uk/siri" version="2419" id="IT:ITC4:StopPlace:AUTOGUIDOVIE:58523">
	<Name>Pavia, Via Scarpone</Name>
	<Centroid>
		<Location>
			<ns2:pos>45.168515 9.209468</ns2:pos>
			<Precision>6</Precision>
		</Location>
	</Centroid>
	<quays>
		<Quay version="2419" id="IT:ITC4:Quay:AUTOGUIDOVIE:58523">
			<Name>Pavia, Via Scarpone</Name>
			<Centroid>
				<Location>
					<ns2:pos>45.168515 9.209468</ns2:pos>
					<Precision>6</Precision>
				</Location>
			</Centroid>
		</Quay>
	</quays>
</StopPlace>
```

I'm not sure why that is but it is valid NeTEx and easy to support.

### Issue

https://github.com/noi-techpark/opendatahub-mentor-otp/issues/330

### Unit tests

Added.

### Documentation

n/a

cc @flaktack @rcavaliere