### PR TITLE
Allow very large NeTEx versions

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
+++ b/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.netex.support;
 
-import static java.util.Comparator.comparingInt;
+import static java.util.Comparator.comparingDouble;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -39,11 +39,11 @@ public class NetexVersionHelper {
    * defines this as follows: "Use "any" if the VERSION is unknown (note that this will trigger NeTEx's
    * XML automatic consistency check)."
    */
-  public static int versionOf(EntityInVersionStructure e) {
+  public static double versionOf(EntityInVersionStructure e) {
     if (e.getVersion().equals(ANY)) {
       return UNKNOWN_VERSION;
     } else {
-      return Integer.parseInt(e.getVersion());
+      return Double.parseDouble(e.getVersion());
     }
   }
 
@@ -51,8 +51,8 @@ public class NetexVersionHelper {
    * Return the latest (maximum) version number for the given {@code list} of elements. If no
    * elements exist in the collection {@code -1} is returned.
    */
-  public static int latestVersionIn(Collection<? extends EntityInVersionStructure> list) {
-    return list.stream().mapToInt(NetexVersionHelper::versionOf).max().orElse(UNKNOWN_VERSION);
+  public static double latestVersionIn(Collection<? extends EntityInVersionStructure> list) {
+    return list.stream().mapToDouble(NetexVersionHelper::versionOf).max().orElse(UNKNOWN_VERSION);
   }
 
   /**
@@ -69,7 +69,7 @@ public class NetexVersionHelper {
    * Return a comparator to compare {@link EntityInVersionStructure} elements by <b>version</b>.
    */
   public static <T extends EntityInVersionStructure> Comparator<T> comparingVersion() {
-    return comparingInt(NetexVersionHelper::versionOf);
+    return comparingDouble(NetexVersionHelper::versionOf);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
+++ b/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
@@ -43,7 +43,7 @@ public class NetexVersionHelper {
     if (e.getVersion().equals(ANY)) {
       return UNKNOWN_VERSION;
     } else {
-      return Long.parseUnsignedLong(e.getVersion());
+      return Long.parseLong(e.getVersion());
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
+++ b/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
@@ -1,6 +1,6 @@
 package org.opentripplanner.netex.support;
 
-import static java.util.Comparator.comparingDouble;
+import static java.util.Comparator.comparingLong;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -23,7 +23,7 @@ public class NetexVersionHelper {
   /**
    * A special value that represents an unknown version.
    */
-  private static final int UNKNOWN_VERSION = -1;
+  private static final long UNKNOWN_VERSION = -1;
 
   /**
    * private constructor to prevent instantiation of utility class
@@ -39,11 +39,11 @@ public class NetexVersionHelper {
    * defines this as follows: "Use "any" if the VERSION is unknown (note that this will trigger NeTEx's
    * XML automatic consistency check)."
    */
-  public static double versionOf(EntityInVersionStructure e) {
+  public static long versionOf(EntityInVersionStructure e) {
     if (e.getVersion().equals(ANY)) {
       return UNKNOWN_VERSION;
     } else {
-      return Double.parseDouble(e.getVersion());
+      return Long.parseUnsignedLong(e.getVersion());
     }
   }
 
@@ -51,8 +51,8 @@ public class NetexVersionHelper {
    * Return the latest (maximum) version number for the given {@code list} of elements. If no
    * elements exist in the collection {@code -1} is returned.
    */
-  public static double latestVersionIn(Collection<? extends EntityInVersionStructure> list) {
-    return list.stream().mapToDouble(NetexVersionHelper::versionOf).max().orElse(UNKNOWN_VERSION);
+  public static long latestVersionIn(Collection<? extends EntityInVersionStructure> list) {
+    return list.stream().mapToLong(NetexVersionHelper::versionOf).max().orElse(UNKNOWN_VERSION);
   }
 
   /**
@@ -69,7 +69,7 @@ public class NetexVersionHelper {
    * Return a comparator to compare {@link EntityInVersionStructure} elements by <b>version</b>.
    */
   public static <T extends EntityInVersionStructure> Comparator<T> comparingVersion() {
-    return comparingDouble(NetexVersionHelper::versionOf);
+    return comparingLong(NetexVersionHelper::versionOf);
   }
 
   /**

--- a/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
+++ b/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
@@ -43,7 +43,11 @@ public class NetexVersionHelper {
     if (e.getVersion().equals(ANY)) {
       return UNKNOWN_VERSION;
     } else {
-      return Long.parseLong(e.getVersion());
+      try {
+        return Long.parseLong(e.getVersion());
+      } catch (NumberFormatException _) {
+        return UNKNOWN_VERSION;
+      }
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
+++ b/application/src/main/java/org/opentripplanner/netex/support/NetexVersionHelper.java
@@ -40,7 +40,7 @@ public class NetexVersionHelper {
    * XML automatic consistency check)."
    */
   public static long versionOf(EntityInVersionStructure e) {
-    if (e.getVersion().equals(ANY)) {
+    if (ANY.equals(e.getVersion())) {
       return UNKNOWN_VERSION;
     } else {
       try {

--- a/application/src/test/java/org/opentripplanner/netex/support/NetexVersionHelperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/support/NetexVersionHelperTest.java
@@ -21,12 +21,8 @@ import org.rutebanken.netex.model.ValidBetween;
 
 class NetexVersionHelperTest {
 
-  private static final EntityInVersionStructure E_VER_1 =
-    new EntityInVersionStructure().withVersion("1");
-  private static final EntityInVersionStructure E_VER_2 =
-    new EntityInVersionStructure().withVersion("2");
-  private static final EntityInVersionStructure E_VER_ANY =
-    new EntityInVersionStructure().withVersion("any");
+  private static final EntityInVersionStructure E_VER_1 = versionedEntity("1");
+  private static final EntityInVersionStructure E_VER_2 = versionedEntity("2");
 
   @Test
   void versionOfTest() {
@@ -35,7 +31,7 @@ class NetexVersionHelperTest {
 
   @Test
   void any() {
-    assertEquals(-1, versionOf(E_VER_ANY));
+    assertEquals(-1, versionOf(versionedEntity("any")));
   }
 
   @Test
@@ -51,13 +47,16 @@ class NetexVersionHelperTest {
   }
 
   @Test
+  void veryLargeVersion() {
+    assertEquals(20260819234001d, versionOf(versionedEntity("20260819234001")));
+  }
+
+  @Test
   void comparingVersionTest() {
     // Given a comparator (subject under test)
     Comparator<EntityInVersionStructure> subject = comparingVersion();
     // And a entity with version as the E_VER_1 entity
-    EntityInVersionStructure sameVersionAs_E_VER_1 = new EntityInVersionStructure().withVersion(
-      "1"
-    );
+    EntityInVersionStructure sameVersionAs_E_VER_1 = versionedEntity("1");
 
     // Then expect equals versions to return zero
     assertEquals(0, subject.compare(E_VER_1, sameVersionAs_E_VER_1));
@@ -101,5 +100,9 @@ class NetexVersionHelperTest {
     assertEquals(may2nd, firstValidDateTime(List.of(pFrom2ndTo3rd), may2nd));
     assertEquals(may3rd, firstValidDateTime(List.of(pFrom2ndTo3rd), may3rd));
     assertNull(firstValidDateTime(List.of(pFrom2ndTo3rd), may4th));
+  }
+
+  private static EntityInVersionStructure versionedEntity(String any) {
+    return new EntityInVersionStructure().withVersion(any);
   }
 }

--- a/application/src/test/java/org/opentripplanner/netex/support/NetexVersionHelperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/support/NetexVersionHelperTest.java
@@ -52,6 +52,11 @@ class NetexVersionHelperTest {
   }
 
   @Test
+  void alphabeticVersion() {
+    assertEquals(-1, versionOf(versionedEntity("AAA")));
+  }
+
+  @Test
   void comparingVersionTest() {
     // Given a comparator (subject under test)
     Comparator<EntityInVersionStructure> subject = comparingVersion();
@@ -103,6 +108,6 @@ class NetexVersionHelperTest {
   }
 
   private static EntityInVersionStructure versionedEntity(String version) {
-    return new EntityInVersionStructure().withVersion(any);
+    return new EntityInVersionStructure().withVersion(version);
   }
 }

--- a/application/src/test/java/org/opentripplanner/netex/support/NetexVersionHelperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/support/NetexVersionHelperTest.java
@@ -48,7 +48,7 @@ class NetexVersionHelperTest {
 
   @Test
   void veryLargeVersion() {
-    assertEquals(20260819234001d, versionOf(versionedEntity("20260819234001")));
+    assertEquals(20260819234001L, versionOf(versionedEntity("20260819234001")));
   }
 
   @Test
@@ -102,7 +102,7 @@ class NetexVersionHelperTest {
     assertNull(firstValidDateTime(List.of(pFrom2ndTo3rd), may4th));
   }
 
-  private static EntityInVersionStructure versionedEntity(String any) {
+  private static EntityInVersionStructure versionedEntity(String version) {
     return new EntityInVersionStructure().withVersion(any);
   }
 }


### PR DESCRIPTION
### Summary

An Austrian NeTEx feed uses the date-time-ish ID `20260819234001` which causes OTP to crash during graph building:

```
Caused by: java.lang.NumberFormatException: For input string: "20260819234001"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:565)
	at java.base/java.lang.Integer.parseInt(Integer.java:662)
	at org.opentripplanner.netex.support.NetexVersionHelper.versionOf(NetexVersionHelper.java:46)
	at org.opentripplanner.netex.index.hierarchy.HierarchicalVersionMapById.isNewerOrSameVersionComparedWithExistingValues(HierarchicalVersionMapById.java:115)
	at org.opentripplanner.netex.index.hierarchy.HierarchicalVersionMapById.isNewerOrSameVersionComparedWithExistingValues(HierarchicalVersionMapById.java:23)
	at org.opentripplanner.netex.mapping.StopAndStationMapper.addStopToParentIfNotPresent(StopAndStationMapper.java:182)
	at org.opentripplanner.netex.mapping.StopAndStationMapper.mapParentAndChildStops(StopAndStationMapper.java:109)
	at org.opentripplanner.netex.mapping.NetexMapper.mapStopPlaceAndQuays(NetexMapper.java:322)
	at org.opentripplanner.netex.mapping.NetexMapper.mapNetexToOtp(NetexMapper.java:190)
	at org.opentripplanner.netex.NetexBundle.loadFilesThenMapToTransitRepository(NetexBundle.java:179)
	at org.opentripplanner.netex.NetexBundle.lambda$loadFileEntries$1(NetexBundle.java:139)
	at org.opentripplanner.netex.NetexBundle.scopeInputData(NetexBundle.java:155)
	at org.opentripplanner.netex.NetexBundle.lambda$loadFileEntries$0(NetexBundle.java:137)
```

It's quite a strange version but it's valid NeTEx and easy to support.

### Issue

https://github.com/noi-techpark/opendatahub-mentor-otp/issues/330

### Unit tests

Added.

cc @flaktack 