### PR TITLE
Drop UIC operating periods without a start date

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
@@ -55,6 +55,7 @@ public class DayTypeAssignmentMapper {
   // Result data
   private final Set<LocalDate> dates = new HashSet<>();
   private final Set<LocalDate> datesToRemove = new HashSet<>();
+  private final DataImportIssueStore issueStore;
 
   /**
    * This is private to block instantiating this class from outside. This enforces thread-safety
@@ -63,11 +64,13 @@ public class DayTypeAssignmentMapper {
   private DayTypeAssignmentMapper(
     DayType dayType,
     ReadOnlyHierarchicalMapById<OperatingDay> operatingDays,
-    ReadOnlyHierarchicalMapById<OperatingPeriod_VersionStructure> operatingPeriods
+    ReadOnlyHierarchicalMapById<OperatingPeriod_VersionStructure> operatingPeriods,
+    DataImportIssueStore issueStore
   ) {
     this.dayType = dayType;
     this.operatingDays = operatingDays;
     this.operatingPeriods = operatingPeriods;
+    this.issueStore = issueStore;
   }
 
   /**
@@ -84,7 +87,7 @@ public class DayTypeAssignmentMapper {
     Map<String, Set<LocalDate>> result = new HashMap<>();
 
     for (var dayType : dayTypes.localValues()) {
-      var mapper = new DayTypeAssignmentMapper(dayType, operatingDays, operatingPeriods);
+      var mapper = new DayTypeAssignmentMapper(dayType, operatingDays, operatingPeriods, issueStore);
 
       for (DayTypeAssignment it : assignments.lookup(dayType.getId())) {
         mapper.map(it);
@@ -185,7 +188,13 @@ public class DayTypeAssignmentMapper {
       LocalDateTime endDate = uicOperatingPeriod.getToDate().plusDays(1);
       LocalDateTime date = uicOperatingPeriod.getFromDate();
 
-      addDates(uicOperatingPeriod.getValidDayBits(), isAvailable, endDate, date);
+      if(date != null){
+        addDates(uicOperatingPeriod.getValidDayBits(), isAvailable, endDate, date);
+      }
+      else {
+        issueStore.add("InvalidUicOperatingPeriod", "Missing start date for UIC operating period " + uicOperatingPeriod.getId());
+      }
+
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
@@ -87,7 +87,12 @@ public class DayTypeAssignmentMapper {
     Map<String, Set<LocalDate>> result = new HashMap<>();
 
     for (var dayType : dayTypes.localValues()) {
-      var mapper = new DayTypeAssignmentMapper(dayType, operatingDays, operatingPeriods, issueStore);
+      var mapper = new DayTypeAssignmentMapper(
+        dayType,
+        operatingDays,
+        operatingPeriods,
+        issueStore
+      );
 
       for (DayTypeAssignment it : assignments.lookup(dayType.getId())) {
         mapper.map(it);
@@ -188,13 +193,14 @@ public class DayTypeAssignmentMapper {
       LocalDateTime endDate = uicOperatingPeriod.getToDate().plusDays(1);
       LocalDateTime date = uicOperatingPeriod.getFromDate();
 
-      if(date != null){
+      if (date != null) {
         addDates(uicOperatingPeriod.getValidDayBits(), isAvailable, endDate, date);
+      } else {
+        issueStore.add(
+          "InvalidUicOperatingPeriod",
+          "Missing start date for UIC operating period " + uicOperatingPeriod.getId()
+        );
       }
-      else {
-        issueStore.add("InvalidUicOperatingPeriod", "Missing start date for UIC operating period " + uicOperatingPeriod.getId());
-      }
-
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapper.java
@@ -55,7 +55,6 @@ public class DayTypeAssignmentMapper {
   // Result data
   private final Set<LocalDate> dates = new HashSet<>();
   private final Set<LocalDate> datesToRemove = new HashSet<>();
-  private final DataImportIssueStore issueStore;
 
   /**
    * This is private to block instantiating this class from outside. This enforces thread-safety
@@ -64,13 +63,11 @@ public class DayTypeAssignmentMapper {
   private DayTypeAssignmentMapper(
     DayType dayType,
     ReadOnlyHierarchicalMapById<OperatingDay> operatingDays,
-    ReadOnlyHierarchicalMapById<OperatingPeriod_VersionStructure> operatingPeriods,
-    DataImportIssueStore issueStore
+    ReadOnlyHierarchicalMapById<OperatingPeriod_VersionStructure> operatingPeriods
   ) {
     this.dayType = dayType;
     this.operatingDays = operatingDays;
     this.operatingPeriods = operatingPeriods;
-    this.issueStore = issueStore;
   }
 
   /**
@@ -87,12 +84,7 @@ public class DayTypeAssignmentMapper {
     Map<String, Set<LocalDate>> result = new HashMap<>();
 
     for (var dayType : dayTypes.localValues()) {
-      var mapper = new DayTypeAssignmentMapper(
-        dayType,
-        operatingDays,
-        operatingPeriods,
-        issueStore
-      );
+      var mapper = new DayTypeAssignmentMapper(dayType, operatingDays, operatingPeriods);
 
       for (DayTypeAssignment it : assignments.lookup(dayType.getId())) {
         mapper.map(it);
@@ -191,20 +183,15 @@ public class DayTypeAssignmentMapper {
       addDates(isAvailable, daysOfWeek, endDate, date);
     } else if (period instanceof UicOperatingPeriod uicOperatingPeriod) {
       LocalDateTime endDate = uicOperatingPeriod.getToDate().plusDays(1);
-      LocalDateTime date = uicOperatingPeriod.getFromDate();
+      LocalDateTime date = getOperatingPeriodStartDate(uicOperatingPeriod);
 
-      if (date != null) {
-        addDates(uicOperatingPeriod.getValidDayBits(), isAvailable, endDate, date);
-      } else {
-        issueStore.add(
-          "InvalidUicOperatingPeriod",
-          "Missing start date for UIC operating period " + uicOperatingPeriod.getId()
-        );
-      }
+      addDates(uicOperatingPeriod.getValidDayBits(), isAvailable, endDate, date);
     }
   }
 
-  private LocalDateTime getOperatingPeriodStartDate(OperatingPeriod operatingPeriod) {
+  private LocalDateTime getOperatingPeriodStartDate(
+    OperatingPeriod_VersionStructure operatingPeriod
+  ) {
     if (operatingPeriod.getFromDate() != null) {
       return operatingPeriod.getFromDate();
     }

--- a/application/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.mapping.calendar;
 
+import static com.google.common.truth.Truth.assertThat;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -490,6 +491,32 @@ class DayTypeAssignmentMapperTest {
 
     // THEN - the valid-day-bits decide, the second day is skipped
     assertEquals("[2020-11-01, 2020-11-03]", toStr(result, DAY_TYPE_1));
+  }
+
+  @Test
+  void rejectUicPeriodWithoutStartDate() {
+    var dayTypes = new HierarchicalMapById<DayType>();
+    var assignments = new HierarchicalMultimap<String, DayTypeAssignment>();
+    var periods = new HierarchicalMapById<OperatingPeriod_VersionStructure>();
+
+    dayTypes.add(createDayTypeWithProperties(DAY_TYPE_1, new PropertyOfDay()));
+    periods.add(createUicOperatingPeriod(OP_1, null, D2020_11_03, "101"));
+    assignments.add(DAY_TYPE_1, createDayTypeAssignmentWithPeriod(DAY_TYPE_1, OP_1, AVAILABLE));
+
+    var issueStore = new DefaultDataImportIssueStore();
+    Map<String, Set<LocalDate>> result = DayTypeAssignmentMapper.mapDayTypes(
+      dayTypes,
+      assignments,
+      EMPTY_OPERATING_DAYS,
+      periods,
+      issueStore
+    );
+
+    assertEquals("[]", toStr(result, DAY_TYPE_1));
+
+    assertThat(issueStore.listIssues().stream().map(Object::toString)).contains(
+      "Issue{type: 'InvalidUicOperatingPeriod', message: 'Missing start date for UIC operating period OP-1'}"
+    );
   }
 
   /* private helper methods */

--- a/application/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/calendar/DayTypeAssignmentMapperTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.opentripplanner.netex.NetexTestDataSupport.createDayType;
 import static org.opentripplanner.netex.NetexTestDataSupport.createDayTypeAssignment;
 import static org.opentripplanner.netex.NetexTestDataSupport.createDayTypeAssignmentWithOpDay;
@@ -503,20 +504,17 @@ class DayTypeAssignmentMapperTest {
     periods.add(createUicOperatingPeriod(OP_1, null, D2020_11_03, "101"));
     assignments.add(DAY_TYPE_1, createDayTypeAssignmentWithPeriod(DAY_TYPE_1, OP_1, AVAILABLE));
 
-    var issueStore = new DefaultDataImportIssueStore();
-    Map<String, Set<LocalDate>> result = DayTypeAssignmentMapper.mapDayTypes(
-      dayTypes,
-      assignments,
-      EMPTY_OPERATING_DAYS,
-      periods,
-      issueStore
+    var ex = assertThrows(IllegalArgumentException.class, () ->
+      DayTypeAssignmentMapper.mapDayTypes(
+        dayTypes,
+        assignments,
+        EMPTY_OPERATING_DAYS,
+        periods,
+        null
+      )
     );
 
-    assertEquals("[]", toStr(result, DAY_TYPE_1));
-
-    assertThat(issueStore.listIssues().stream().map(Object::toString)).contains(
-      "Issue{type: 'InvalidUicOperatingPeriod', message: 'Missing start date for UIC operating period OP-1'}"
-    );
+    assertThat(ex).hasMessageThat().isEqualTo("Missing start date for operating period OP-1");
   }
 
   /* private helper methods */


### PR DESCRIPTION
### Summary

UIC operating periods without a start date would crash the graph build with the following error.


This checks that case and adds an issue instead.

### Issue

https://github.com/noi-techpark/opendatahub-mentor-otp/issues/330

### Unit tests

Added.

cc @flaktack 