### PR TITLE
Serialize TIntObjectHashMap entries directly

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/KryoBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/KryoBuilder.java
@@ -12,6 +12,7 @@ import de.javakaffee.kryoserializers.guava.HashMultimapSerializer;
 import gnu.trove.impl.hash.TPrimitiveHash;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.hash.TIntIntHashMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,7 @@ public final class KryoBuilder {
     kryo.addDefaultSerializer(TPrimitiveHash.class, ExternalizableSerializer.class);
     kryo.register(TIntArrayList.class, new TIntArrayListSerializer());
     kryo.register(TIntIntHashMap.class, new TIntIntHashMapSerializer());
+    kryo.register(TIntObjectHashMap.class, new TIntObjectHashMapSerializer());
 
     // Add support for the package local java.util.ImmutableCollections.
     // Not supported properly in the current com.conveyal:kryo-tools:1.4.0.

--- a/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/TIntObjectHashMapSerializer.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/TIntObjectHashMapSerializer.java
@@ -1,0 +1,47 @@
+package org.opentripplanner.routing.graph.kryosupport;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import gnu.trove.impl.Constants;
+import gnu.trove.iterator.TIntObjectIterator;
+import gnu.trove.map.hash.TIntObjectHashMap;
+
+/**
+ * Direct Kryo serializer for Trove's {@link TIntObjectHashMap}, replacing the {@code
+ * Externalizable} fallback.
+ */
+class TIntObjectHashMapSerializer extends Serializer<TIntObjectHashMap<?>> {
+
+  @Override
+  public void write(Kryo kryo, Output output, TIntObjectHashMap<?> map) {
+    output.writeVarInt(map.getNoEntryKey(), false);
+    output.writeVarInt(map.size(), true);
+    TIntObjectIterator<?> it = map.iterator();
+    while (it.hasNext()) {
+      it.advance();
+      output.writeVarInt(it.key(), true);
+      kryo.writeClassAndObject(output, it.value());
+    }
+  }
+
+  @Override
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public TIntObjectHashMap<?> read(
+    Kryo kryo,
+    Input input,
+    Class<? extends TIntObjectHashMap<?>> type
+  ) {
+    int noEntryKey = input.readVarInt(false);
+    int size = input.readVarInt(true);
+    TIntObjectHashMap map = new TIntObjectHashMap(size, Constants.DEFAULT_LOAD_FACTOR, noEntryKey);
+    // Register the map before reading the values, so values referencing back to the map resolve.
+    kryo.reference(map);
+    for (int i = 0; i < size; i++) {
+      int key = input.readVarInt(true);
+      map.put(key, kryo.readClassAndObject(input));
+    }
+    return map;
+  }
+}

--- a/application/src/test/java/org/opentripplanner/routing/graph/kryosupport/TIntObjectHashMapSerializerTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/graph/kryosupport/TIntObjectHashMapSerializerTest.java
@@ -1,0 +1,58 @@
+package org.opentripplanner.routing.graph.kryosupport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import gnu.trove.map.hash.TIntObjectHashMap;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TIntObjectHashMapSerializerTest {
+
+  @Test
+  void roundTrip() {
+    var map = new TIntObjectHashMap<String>();
+    map.put(1, "one");
+    map.put(-42, "minus forty-two");
+    map.put(100_000, "hundred thousand");
+
+    TIntObjectHashMap<?> read = writeAndRead(map);
+
+    assertEquals(3, read.size());
+    assertEquals("one", read.get(1));
+    assertEquals("minus forty-two", read.get(-42));
+    assertEquals("hundred thousand", read.get(100_000));
+    assertEquals(map.getNoEntryKey(), read.getNoEntryKey());
+  }
+
+  @Test
+  void emptyMap() {
+    TIntObjectHashMap<?> read = writeAndRead(new TIntObjectHashMap<String>());
+    assertTrue(read.isEmpty());
+  }
+
+  @Test
+  void sharedValuesKeepIdentity() {
+    var shared = List.of("shared");
+    var map = new TIntObjectHashMap<List<String>>();
+    map.put(1, shared);
+    map.put(2, shared);
+
+    TIntObjectHashMap<?> read = writeAndRead(map);
+
+    assertSame(read.get(1), read.get(2));
+  }
+
+  private static TIntObjectHashMap<?> writeAndRead(TIntObjectHashMap<?> map) {
+    var kryo = KryoBuilder.create();
+    var bytes = new ByteArrayOutputStream();
+    try (var out = new Output(bytes)) {
+      kryo.writeClassAndObject(out, map);
+    }
+    return (TIntObjectHashMap<?>) kryo.readClassAndObject(new Input(bytes.toByteArray()));
+  }
+}


### PR DESCRIPTION
## Summary

A graph containing empirical delay data is observed to be slower to deserialize. The root cause is the use of TIntObjectHashMap objects that are serialized/deserialized through Kryo's default Externalizable serializer, which is slow.

### Fix
Replaces the `Externalizable` fallback for Trove's `TIntObjectHashMap` with a dedicated Kryo serializer, following the pattern of conveyal kryo-tools' `TIntIntHashMapSerializer` (whose comment notes it is "much faster than using the Kryo Externalizable serializer").

The `Externalizable` path routes every map entry through the `KryoObjectInput`/`KryoObjectOutput` adapter and serializes Trove-internal bookkeeping. Writing the entries directly is both faster and smaller. In a graph with empirical delay data, `TIntObjectHashMap` is the dominant Trove type still on the `Externalizable` path (~290k instances on the Norway graph).

## Measurements

A/B against current `dev-2.x` on the Norway production graph (NeTEx + empirical delay + emissions, 2.05 GB).

| metric | dev-2.x | this PR | Δ |
|---|---|---|---|
| graph file size | 2,055,025,880 B | 2,002,418,215 B | **−52.6 MB (−2.6%)** |
| graph read (median) | 51.6 s | 41.4 s | **−10.2 s (−20%)** |
| graph write (median) | 59.1 s | 50.0 s | **−9.1 s (−15%)** |


## Issue

Close #7931

## Unit tests

Added unit tests.

