### PR TITLE
Pre-size the Kryo reference resolver for graph serialization

### DIFF
--- a/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/KryoBuilder.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/KryoBuilder.java
@@ -27,6 +27,13 @@ import org.opentripplanner.standalone.config.RouterConfig;
 public final class KryoBuilder {
 
   /**
+   * Expected upper bound on the number of reference-tracked objects in a serialized graph. The
+   * Norway graph (2 GB on disk) holds ~59 million; overshooting only rounds the pre-sized tables
+   * up to the next power of two, while undershooting merely re-introduces some rehash churn.
+   */
+  private static final int EXPECTED_GRAPH_OBJECTS = 64_000_000;
+
+  /**
    * This method allows reproducibly creating Kryo (de)serializer instances with exactly the same
    * configuration. This allows us to use identically configured instances for serialization and
    * deserialization.
@@ -40,7 +47,7 @@ public final class KryoBuilder {
   public static Kryo create() {
     // For generating a histogram of serialized classes with associated serializers:
     // Kryo kryo = new Kryo(new InstanceCountingClassResolver(), new MapReferenceResolver(), new DefaultStreamFactory());
-    Kryo kryo = new Kryo();
+    Kryo kryo = new Kryo(new PreSizedReferenceResolver(EXPECTED_GRAPH_OBJECTS));
     // Allow serialization of unrecognized classes, for which we haven't manually set up a serializer.
     // We might actually want to manually register a serializer for every class, to be safe.
     kryo.setRegistrationRequired(false);

--- a/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/PreSizedReferenceResolver.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/kryosupport/PreSizedReferenceResolver.java
@@ -1,0 +1,49 @@
+package org.opentripplanner.routing.graph.kryosupport;
+
+import com.esotericsoftware.kryo.util.MapReferenceResolver;
+
+/**
+ * A {@link MapReferenceResolver} pre-sized for the number of reference-tracked objects in an OTP
+ * graph. With references enabled, Kryo tracks every serialized object: a country-sized graph holds
+ * tens of millions of them (~59 million measured for Norway). Kryo's default resolver grows to
+ * that size incrementally — the write side rehashes its identity map ~20 times, each rehash
+ * re-inserting every entry, and the read side repeatedly grows an ArrayList. Pre-sizing removes
+ * that churn from graph save and load (measured: -16% save time for Norway).
+ * <p>
+ * Each side is sized lazily on its first use, so a serializing Kryo never allocates the read-side
+ * list and, more importantly, a deserializing Kryo never allocates the ~1 GB write-side identity
+ * map.
+ * <p>
+ * The expected count is passed to the superclass as {@code maximumCapacity} as well, so that the
+ * {@link MapReferenceResolver#reset()} called between the top-level objects in a graph file does
+ * not trim the pre-sized structures back down.
+ */
+class PreSizedReferenceResolver extends MapReferenceResolver {
+
+  private final int expectedObjects;
+  private boolean writeSideSized = false;
+  private boolean readSideSized = false;
+
+  PreSizedReferenceResolver(int expectedObjects) {
+    super(expectedObjects);
+    this.expectedObjects = expectedObjects;
+  }
+
+  @Override
+  public int addWrittenObject(Object object) {
+    if (!writeSideSized) {
+      writeSideSized = true;
+      writtenObjects.ensureCapacity(expectedObjects);
+    }
+    return super.addWrittenObject(object);
+  }
+
+  @Override
+  public int nextReadId(Class type) {
+    if (!readSideSized) {
+      readSideSized = true;
+      readObjects.ensureCapacity(expectedObjects);
+    }
+    return super.nextReadId(type);
+  }
+}


### PR DESCRIPTION
## Summary

Graph serialization runs Kryo with `references=true`, so Kryo reference-tracks every object it
(de)serializes. A country-sized graph holds tens of millions of tracked objects — ~59 million
measured for the Norway graph (2 GB on disk). Kryo's default `MapReferenceResolver` grows to that
size incrementally: the write side rehashes its identity map ~20 times, each rehash re-inserting
every entry (several GB of cumulative table allocations), and the read side repeatedly grows an
`ArrayList`.

This PR replaces the default resolver with a `PreSizedReferenceResolver` that sizes each side for
an expected object count (constant, 64 M), removing the growth churn from graph save and load.

Details:

- **Each side is sized lazily on first use**: a deserializing Kryo never allocates the ~1 GB
  write-side identity map it would never use, and vice versa. (An eager version cost +5 s on
  every graph load.)
- The expected count is also passed to the superclass as `maximumCapacity`, so the `reset()`
  Kryo performs between the top-level objects in one graph file does not trim the pre-sized
  structures back down.
- Mis-sizing is benign in both directions: overshooting only rounds the tables up to the next
  power of two; undershooting merely re-introduces some rehash churn.
- No wire change — the serialized output is unaffected, so **no serialization version bump** and
  old graphs load unchanged.

## Measurements

A/B on the Norway production graph (NeTEx + OSM, 2.05 GB `graph.obj`, 59,192,571 tracked objects),
`GraphResave` harness (one load + one save per run), 5 interleaved rounds with arm order rotated,
warm page cache, `-Xmx16g`:

| | base | pre-sized resolver | Δ |
|---|---|---|---|
| save (median) | 35.0 s | 29.5 s | **−5.5 s (−16 %)** |
| load (median) | 28.6 s | 27.6 s | −1.0 s (−3.5 %) |

The save win is unambiguous — every pre-sized rep (28.1–29.6 s) beat every base rep
(32.9–38.4 s). The load win is small but consistent (5/5 reps), as expected: growing an
`ArrayList` is just `System.arraycopy`, while rehashing an identity map re-inserts every entry.

## Notes for reviewers

The pre-sized write table costs ~1 GB up front (at 64 M expected objects, load factor 0.8,
compressed oops) for **every** save, including small graphs that would never have grown that far.
Saving a graph is a batch operation that runs next to graph building, which needs far more heap
than this on any real dataset, so the constant is intentionally not made configurable. The
read-side list is ~256 MB, similarly lazy.
