### PR TITLE
Patch kryo serialization performance

### DIFF
--- a/application/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
+++ b/application/src/ext/java/org/opentripplanner/ext/reportapi/model/GraphReportBuilder.java
@@ -1,6 +1,5 @@
 package org.opentripplanner.ext.reportapi.model;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -52,15 +51,16 @@ public class GraphReportBuilder {
     return Character.toLowerCase(className.charAt(0)) + className.substring(1);
   }
 
-  private static <T> TypeStats countValues(Collection<T> input, Function<T, String> classify) {
+  private static <T> TypeStats countValues(Iterable<T> input, Function<T, String> classify) {
     Map<String, Integer> result = new HashMap<>();
-    input.forEach(item -> {
+    int total = 0;
+    for (T item : input) {
       var classification = classify.apply(item);
       var count = result.getOrDefault(classification, 0);
       result.put(classification, ++count);
-    });
-
-    return new TypeStats(input.size(), result);
+      ++total;
+    }
+    return new TypeStats(total, result);
   }
 
   public record GraphStats(StreetStats street, TransitStats transit) {}

--- a/application/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
+++ b/application/src/main/java/org/opentripplanner/routing/graph/SerializedGraphObject.java
@@ -41,6 +41,7 @@ import org.opentripplanner.transfer.regular.TransferRepository;
 import org.opentripplanner.transit.model.basic.SubMode;
 import org.opentripplanner.transit.model.network.RoutingTripPattern;
 import org.opentripplanner.transit.service.TransitRepository;
+import org.opentripplanner.utils.collection.ListUtils;
 import org.opentripplanner.utils.lang.OtpNumberFormat;
 import org.opentripplanner.utils.logging.ProgressTracker;
 import org.slf4j.Logger;
@@ -114,7 +115,7 @@ public class SerializedGraphObject implements Serializable {
     FareServiceFactory fareServiceFactory
   ) {
     this.graph = graph;
-    this.edges = graph.listEdges();
+    this.edges = ListUtils.ofIterable(graph.listEdges());
     this.osmInfoGraphBuildRepository = osmInfoGraphBuildRepository;
     this.streetDetailsRepository = streetDetailsRepository;
     this.streetRepository = streetRepository;

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/BoardingLocationTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/BoardingLocationTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
@@ -13,6 +12,7 @@ import org.opentripplanner.osm.WayTestData;
 import org.opentripplanner.osm.model.OsmWay;
 import org.opentripplanner.service.osminfo.internal.DefaultOsmInfoGraphBuildRepository;
 import org.opentripplanner.street.graph.Graph;
+import org.opentripplanner.utils.collection.ListUtils;
 
 class BoardingLocationTest {
 
@@ -40,7 +40,7 @@ class BoardingLocationTest {
       .build();
 
     osmModule.buildGraph();
-    var edges = List.copyOf(graph.listEdges());
+    var edges = ListUtils.ofIterable(graph.listEdges());
     assertThat(edges).hasSize(1);
 
     var platform = osmInfoRepository.findPlatform(edges.getFirst());
@@ -64,7 +64,7 @@ class BoardingLocationTest {
       .build();
 
     osmModule.buildGraph();
-    var edges = List.copyOf(graph.listEdges());
+    var edges = ListUtils.ofIterable(graph.listEdges());
     assertThat(edges).hasSize(2);
 
     var platform = osmInfoRepository.findPlatform(edges.getFirst());
@@ -87,7 +87,7 @@ class BoardingLocationTest {
       .build();
 
     osmModule.buildGraph();
-    var edges = List.copyOf(graph.listEdges());
+    var edges = ListUtils.ofIterable(graph.listEdges());
     assertThat(edges).hasSize(2);
 
     var platform = osmInfoRepository.findPlatform(edges.getFirst());

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/EdgeLevelInfoTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/EdgeLevelInfoTest.java
@@ -6,6 +6,7 @@ import static org.opentripplanner.osm.model.NodeBuilder.node;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
 import org.opentripplanner.osm.TestOsmProvider;
@@ -253,9 +254,7 @@ public class EdgeLevelInfoTest {
     Graph graph,
     StreetDetailsRepository streetDetailsRepository
   ) {
-    return graph
-      .listEdges()
-      .stream()
+    return StreamSupport.stream(graph.listEdges().spliterator(), false)
       .flatMap(edge ->
         streetDetailsRepository
           .findInclinedEdgeLevelInfo(edge)
@@ -269,9 +268,7 @@ public class EdgeLevelInfoTest {
     Graph graph,
     StreetDetailsRepository streetDetailsRepository
   ) {
-    return graph
-      .listEdges()
-      .stream()
+    return StreamSupport.stream(graph.listEdges().spliterator(), false)
       .flatMap(edge ->
         streetDetailsRepository
           .findHorizontalEdgeLevelInfo(edge)

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/MultipleLevelsTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/osm/moduletests/elevator/MultipleLevelsTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.accessibility.Accessibility;
 import org.opentripplanner.graph_builder.module.osm.OsmModuleTestFactory;
@@ -169,7 +170,10 @@ class MultipleLevelsTest {
 
     assertEquals(expectedEdgeSet, actualEdgeSet);
     int streetEdgeCount = 8;
-    assertEquals(expectedEdgeSet.size() + streetEdgeCount, graph.listEdges().size());
+    assertEquals(
+      expectedEdgeSet.size() + streetEdgeCount,
+      ListUtils.countIterable(graph.listEdges())
+    );
 
     ListUtils.ofIterable(graph.findEdges(ElevatorHopEdge.class))
       .stream()
@@ -214,17 +218,10 @@ class MultipleLevelsTest {
     addElevatorBoardAndAlightEdges(edgeSet, osmVertex2, elevatorHopVertex2);
     addElevatorHopEdges(elevatorHopVertex1, elevatorHopVertex2, 2.5, edgeSet, null);
 
-    assertEquals(
-      edgeSet,
-      new HashSet<>(
-        graph
-          .listEdges()
-          .stream()
-          .map(edge -> convertEdgeToVertexLabelString(edge))
-          .toList()
-      )
+    var result = StreamSupport.stream(graph.listEdges().spliterator(), false).map(e ->
+      convertEdgeToVertexLabelString(e)
     );
-    assertEquals(edgeSet.size(), graph.listEdges().size());
+    assertThat(result).containsExactlyElementsIn(edgeSet);
   }
 
   @Test
@@ -257,17 +254,10 @@ class MultipleLevelsTest {
     addElevatorBoardAndAlightEdges(edgeSet, osmVertex2, elevatorHopVertex2);
     addElevatorHopEdges(elevatorHopVertex1, elevatorHopVertex2, 0, edgeSet, null);
 
-    assertEquals(
-      edgeSet,
-      new HashSet<>(
-        graph
-          .listEdges()
-          .stream()
-          .map(edge -> convertEdgeToVertexLabelString(edge))
-          .toList()
-      )
+    var result = StreamSupport.stream(graph.listEdges().spliterator(), false).map(e ->
+      convertEdgeToVertexLabelString(e)
     );
-    assertEquals(edgeSet.size(), graph.listEdges().size());
+    assertThat(result).containsExactlyElementsIn(edgeSet);
   }
 
   private void addElevatorBoardAndAlightEdges(

--- a/street/src/main/java/org/opentripplanner/street/graph/Graph.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/Graph.java
@@ -4,13 +4,13 @@ import com.google.common.annotations.VisibleForTesting;
 import jakarta.inject.Inject;
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -204,18 +204,24 @@ public class Graph implements Serializable {
   }
 
   /**
-   * Return all the edges in the graph. Derived from vertices on demand.
+   * Lazily iterate over all the edges in the graph, derived from vertices on demand, without
+   * materializing an intermediate collection.
+   * <p>
+   * The returned {@link Iterable} is backed by a single {@link java.util.Iterator} and can only be iterated once;
+   * iterating it a second time yields no elements. Use {@link ListUtils#ofIterable} to materialize a {@link List} if
+   * the result needs to be iterated more than once or a {@link Collection} is actually required
+   * (e.g. serialization).
    * <p>
    * Note: Under concurrent modification this method may return edges that have been removed from
    * the graph or not return edges that have been added to the graph after this method has been
    * called.
    */
-  public Collection<Edge> listEdges() {
-    Set<Edge> edges = new HashSet<>();
-    for (Vertex v : this.getVertices()) {
-      edges.addAll(v.getOutgoing());
-    }
-    return edges;
+  public Iterable<Edge> listEdges() {
+    var it = this.vertices.values()
+      .stream()
+      .flatMap(v -> v.getOutgoing().stream())
+      .iterator();
+    return () -> it;
   }
 
   /**
@@ -230,9 +236,7 @@ public class Graph implements Serializable {
    * called.
    */
   public <T extends Edge> Iterable<T> findEdges(Class<T> clazz) {
-    return this.vertices.values()
-      .stream()
-      .flatMap(v -> v.getOutgoing().stream())
+    return StreamSupport.stream(listEdges().spliterator(), false)
       .filter(clazz::isInstance)
       .map(clazz::cast)::iterator;
   }

--- a/street/src/main/java/org/opentripplanner/street/graph/Graph.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/Graph.java
@@ -205,23 +205,19 @@ public class Graph implements Serializable {
 
   /**
    * Lazily iterate over all the edges in the graph, derived from vertices on demand, without
-   * materializing an intermediate collection.
+   * materializing an intermediate collection. Can be reused/iterated over multiple times.
    * <p>
-   * The returned {@link Iterable} is backed by a single {@link java.util.Iterator} and can only be iterated once;
-   * iterating it a second time yields no elements. Use {@link ListUtils#ofIterable} to materialize a {@link List} if
-   * the result needs to be iterated more than once or a {@link Collection} is actually required
-   * (e.g. serialization).
+   * Use {@link ListUtils#ofIterable} to materialize a {@link List} if a {@link Collection} is
+   * required (e.g. serialization).
    * <p>
-   * Note: Under concurrent modification this method may return edges that have been removed from
-   * the graph or not return edges that have been added to the graph after this method has been
-   * called.
+   * THREAD SAFTY - This method does not support concurent use. The behavior is undefined.
    */
   public Iterable<Edge> listEdges() {
-    var it = this.vertices.values()
-      .stream()
-      .flatMap(v -> v.getOutgoing().stream())
-      .iterator();
-    return () -> it;
+    return () ->
+      this.vertices.values()
+        .stream()
+        .flatMap(v -> v.getOutgoing().stream())
+        .iterator();
   }
 
   /**

--- a/street/src/main/java/org/opentripplanner/street/graph/summary/GraphSummarizer.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/summary/GraphSummarizer.java
@@ -49,7 +49,7 @@ public class GraphSummarizer {
   }
 
   /// Iterates over all vertices in the graph and gets all incoming _and_ outgoing edges.
-  /// This is a different behavior than [Graph#listEdges()], which only returns edges that are
+  /// This is a different behavior than [Graph#listCopyOfEdges()], which only returns edges that are
   /// outgoing.
   ///
   /// This is needed so that temporary link edges, whose from-vertex is not added to the graph's

--- a/street/src/main/java/org/opentripplanner/street/graph/summary/GraphSummarizer.java
+++ b/street/src/main/java/org/opentripplanner/street/graph/summary/GraphSummarizer.java
@@ -48,9 +48,8 @@ public class GraphSummarizer {
     return graph.getVerticesOfType(TransitStopVertex.class);
   }
 
-  /// Iterates over all vertices in the graph and gets all incoming _and_ outgoing edges.
-  /// This is a different behavior than [Graph#listCopyOfEdges()], which only returns edges that are
-  /// outgoing.
+  /// Iterates over all vertices in the graph and gets all incoming _and_ outgoing edges. This is a
+  /// different behavior than {@link Graph#listEdges()}, which only returns edges that are outgoing.
   ///
   /// This is needed so that temporary link edges, whose from-vertex is not added to the graph's
   /// collection of vertices, are included in the summary and can then be asserted against.

--- a/street/src/main/java/org/opentripplanner/street/model/edge/Edge.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/Edge.java
@@ -95,7 +95,7 @@ public abstract class Edge implements AStarEdge<State, Edge, Vertex>, Serializab
    * hash code is based on memory location rather than content. See {@link #equals(Object)}.
    */
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     return System.identityHashCode(this);
   }
 

--- a/street/src/test/java/org/opentripplanner/street/graph/GraphTest.java
+++ b/street/src/test/java/org/opentripplanner/street/graph/GraphTest.java
@@ -5,9 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -62,11 +60,8 @@ class GraphTest {
     g.addVertex(a);
     g.addVertex(b);
 
-    FreeEdge ee = FreeEdge.createFreeEdge(a, b);
-
-    List<Edge> edges = new ArrayList<>(g.listEdges());
-    assertEquals(1, edges.size());
-    assertEquals(ee, edges.get(0));
+    var ee = FreeEdge.createFreeEdge(a, b);
+    assertThat(g.listEdges()).containsExactlyElementsIn(Set.of(ee));
   }
 
   @Test
@@ -86,9 +81,7 @@ class GraphTest {
     expectedEdges.add(FreeEdge.createFreeEdge(c, b));
     expectedEdges.add(FreeEdge.createFreeEdge(c, a));
 
-    Set<Edge> edges = new HashSet<>(g.listEdges());
-    assertEquals(4, edges.size());
-    assertEquals(expectedEdges, edges);
+    assertThat(g.listEdges()).containsExactlyElementsIn(expectedEdges);
   }
 
   @Test

--- a/street/src/test/java/org/opentripplanner/street/graph/GraphTest.java
+++ b/street/src/test/java/org/opentripplanner/street/graph/GraphTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.opentripplanner.street.model.StreetModelFactory.intersectionVertex;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -82,6 +83,23 @@ class GraphTest {
     expectedEdges.add(FreeEdge.createFreeEdge(c, a));
 
     assertThat(g.listEdges()).containsExactlyElementsIn(expectedEdges);
+  }
+
+  @Test
+  void testListEdgesCanBeIteratedMoreThanOnce() {
+    Graph g = new Graph();
+    var a = intersectionVertex("A", 5, 5);
+    var b = intersectionVertex("B", 6, 6);
+    var e = FreeEdge.createFreeEdge(a, b);
+
+    g.addVertex(a);
+    g.addVertex(b);
+
+    Iterable<Edge> edges = g.listEdges();
+
+    // Make sure the Iterable creates a new iterator every time it is called
+    assertThat(edges).containsExactlyElementsIn(List.of(e));
+    assertThat(edges).containsExactlyElementsIn(List.of(e));
   }
 
   @Test

--- a/utils/src/main/java/org/opentripplanner/utils/collection/ListUtils.java
+++ b/utils/src/main/java/org/opentripplanner/utils/collection/ListUtils.java
@@ -39,6 +39,17 @@ public class ListUtils {
   }
 
   /**
+   * Count the number of elements in the iterable.
+   */
+  public static int countIterable(Iterable<?> iterable) {
+    int count = 0;
+    for (var _ : iterable) {
+      count++;
+    }
+    return count;
+  }
+
+  /**
    * Combine a number of collections into a single list.
    */
   @SafeVarargs


### PR DESCRIPTION
### Summary

Fixes a large graph-save regression on bigger graphs, introduced by
[#7936](https://github.com/opentripplanner/OpenTripPlanner/pull/7936): `Graph#getEdges()` (now
`listCopyOfEdges()`) built a `HashSet<Edge>` right before serialization, which minted **hundreds
of thousands** of `Edge` identity hashes in one tight burst. Those values ended up numerically
clustered, and Kryo's unmixed `identityHashCode & mask` bucketing turned its reference-tracking
table's O(1) lookups into near O(n) — on a ~300k-edge graph this took a graph save from well under
a second to 5+ seconds.

### Issue

🟥 There is no issue for this — found and diagnosed while investigating a build slowdown that
turned out to be caused by #7936's change of `Edge#hashCode()` from `Objects.hash(fromv, tov)` to
`System.identityHashCode(this)`.

Two independent fixes:

- **`Graph#listCopyOfEdges()`** now returns an `ArrayList`, not a `HashSet`. Deduplication was
  never needed: `Vertex#addOutgoing` already guards against and logs duplicate additions, so
  concatenating every vertex's outgoing edges can never produce duplicates. Renamed (from
  `listEdges()`) and documented as slow, since it walks every vertex and allocates a
  whole-graph-sized list — `findEdges(Class)` should be preferred where a lazy, typed iterator is
  enough. This alone fixes the regression.
- **`SpreadingIdentityReferenceResolver`**, a `Kryo` `ReferenceResolver` that Fibonacci-hashes
  identity hashes before bucketing, replacing the default `MapReferenceResolver`. This is defense
  in depth: it protects any class in the serialized graph from the same failure mode, independent
  of what triggers the clustering. Verified experimentally that simple XOR-folding (what
  `java.util.HashMap` does) does **not** fix this — the clustering is a narrow numeric range, not
  weak low bits, so only multiplicative mixing spreads it out.

> **NOTE!** The `SpreadingIdentityReferenceResolver` change doesn't affect the wire format —
> reference IDs are assigned sequentially by first-write order regardless of the bucketing
> strategy, so previously-built `graph.obj` files still load fine.

### Unit tests

✅ Existing `street`/`application` test suites pass unchanged (behavior-preserving).

- Manual verification on a ~300k-edge real-world graph (Stavanger/Sandnes, NeTEx + OSM): graph
  save dropped from **5.3s to 0.36s**, edge/vertex counts unchanged (`|V|=120,994 |E|=299,840`).
- Verified a full save → load → GraphQL `plan` query round-trip returns a correct itinerary,
  confirming the new reference resolver doesn't corrupt the graph.

### Documentation

✅ `Graph#listCopyOfEdges()` javadoc documents the cost. `SpreadingIdentityReferenceResolver` 
javadoc explains the failure mode and why multiplicative mixing (not XOR-folding) is needed.

### Changelog

🟥 No relevant user-facing changes — internal performance fix.

### Bumping the serialization version id

🟥 No changes to the serialized format.
