### PR TITLE
Limit growth of NeTEx stop time index

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapper.java
@@ -3,12 +3,12 @@ package org.opentripplanner.netex.mapping;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import java.util.Collection;
-import java.util.Map;
 import javax.annotation.Nullable;
 import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
+import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
@@ -40,7 +40,7 @@ class NoticeAssignmentMapper {
 
   private final EntityById<Trip> tripsById;
 
-  private final Map<String, StopTime> stopTimesByNetexId;
+  private final HierarchicalMap<String, StopTime> stopTimesByNetexId;
 
   /** Note! The notice mapper caches notices, making sure duplicates are not created. */
   private final NoticeMapper noticeMapper;
@@ -52,7 +52,7 @@ class NoticeAssignmentMapper {
     ReadOnlyHierarchicalMap<String, org.rutebanken.netex.model.Notice> noticesById,
     EntityById<Route> routesById,
     EntityById<Trip> tripsById,
-    Map<String, StopTime> stopTimesByNetexId
+    HierarchicalMap<String, StopTime> stopTimesByNetexId
   ) {
     this.issueStore = issueStore;
     this.idFactory = idFactory;
@@ -131,7 +131,7 @@ class NoticeAssignmentMapper {
     String stopTimeId,
     Notice notice
   ) {
-    StopTime stopTime = stopTimesByNetexId.get(stopTimeId);
+    StopTime stopTime = stopTimesByNetexId.lookup(stopTimeId);
     if (stopTime == null) {
       issueStore.add(
         "NoticeAssigmentWithoutStopTime",

--- a/application/src/main/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapper.java
@@ -8,7 +8,6 @@ import org.opentripplanner.core.model.id.FeedScopedId;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
-import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
 import org.opentripplanner.transit.model.basic.Notice;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
@@ -40,7 +39,7 @@ class NoticeAssignmentMapper {
 
   private final EntityById<Trip> tripsById;
 
-  private final HierarchicalMap<String, StopTime> stopTimesByNetexId;
+  private final ReadOnlyHierarchicalMap<String, StopTime> stopTimesByNetexId;
 
   /** Note! The notice mapper caches notices, making sure duplicates are not created. */
   private final NoticeMapper noticeMapper;
@@ -52,7 +51,7 @@ class NoticeAssignmentMapper {
     ReadOnlyHierarchicalMap<String, org.rutebanken.netex.model.Notice> noticesById,
     EntityById<Route> routesById,
     EntityById<Trip> tripsById,
-    HierarchicalMap<String, StopTime> stopTimesByNetexId
+    ReadOnlyHierarchicalMap<String, StopTime> stopTimesByNetexId
   ) {
     this.issueStore = issueStore;
     this.idFactory = idFactory;

--- a/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
@@ -25,7 +25,7 @@ public class NetexMapperIndexes {
   private final Multimap<String, Station> stationsByMultiModalStationRfs;
   private final Map<String, StopTime> stopTimesByNetexId;
   private final Multimap<String, DatedServiceJourney> datedServiceJourneysBySjId;
-  private NetexMapperIndexes parent;
+  private final NetexMapperIndexes parent;
 
   public NetexMapperIndexes(NetexEntityIndexReadOnlyView index, NetexMapperIndexes parent) {
     this.parent = parent;
@@ -41,11 +41,14 @@ public class NetexMapperIndexes {
         ? parent.datedServiceJourneysBySjId
         : indexDSJBySJId(index.getDatedServiceJourneys());
 
+      // should not be a global list otherwise this would contain the ids of _all_
+      // TimetabledPassingTime instances in the entire feed. (7 million in Norway)
+      this.stopTimesByNetexId = new HashMap<>(parent.stopTimesByNetexId);
+
       // Feed global instances. These fields contain mapping from a netex id to a OTP domain
       // model object, hence we are not adding a lot of data to memory - only the id to object
       // mapping.
       this.stationsByMultiModalStationRfs = parent.stationsByMultiModalStationRfs;
-      this.stopTimesByNetexId = parent.stopTimesByNetexId;
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
@@ -2,11 +2,11 @@ package org.opentripplanner.netex.mapping.support;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import java.util.HashMap;
 import java.util.Map;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.netex.index.api.NetexEntityIndexReadOnlyView;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
+import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.transit.model.site.Station;
 import org.rutebanken.netex.model.DatedServiceJourney;
 
@@ -23,7 +23,7 @@ import org.rutebanken.netex.model.DatedServiceJourney;
 public class NetexMapperIndexes {
 
   private final Multimap<String, Station> stationsByMultiModalStationRfs;
-  private final Map<String, StopTime> stopTimesByNetexId;
+  private final HierarchicalMap<String, StopTime> stopTimesByNetexId;
   private final Multimap<String, DatedServiceJourney> datedServiceJourneysBySjId;
   private final NetexMapperIndexes parent;
 
@@ -33,7 +33,7 @@ public class NetexMapperIndexes {
     if (parent == null) {
       this.datedServiceJourneysBySjId = indexDSJBySJId(index.getDatedServiceJourneys());
       this.stationsByMultiModalStationRfs = ArrayListMultimap.create();
-      this.stopTimesByNetexId = new HashMap<>();
+      this.stopTimesByNetexId = new HierarchicalMap<>();
     } else {
       // Cached by level(shared files, shared group files and group files). If any entries exist at
       // the current level, then they will hide entries at a higher level.
@@ -43,7 +43,7 @@ public class NetexMapperIndexes {
 
       // should not be a global list otherwise this would contain the ids of _all_
       // TimetabledPassingTime instances in the entire feed. (7 million in Norway)
-      this.stopTimesByNetexId = new HashMap<>(parent.stopTimesByNetexId);
+      this.stopTimesByNetexId = new HierarchicalMap<>(parent.stopTimesByNetexId);
 
       // Feed global instances. These fields contain mapping from a netex id to a OTP domain
       // model object, hence we are not adding a lot of data to memory - only the id to object
@@ -70,12 +70,12 @@ public class NetexMapperIndexes {
    * This is needed to assign a notice to a stop time. It is not part of the target
    * TransitDataImport, so we need to temporally cache this here.
    */
-  public Map<String, StopTime> getStopTimesByNetexId() {
+  public HierarchicalMap<String, StopTime> getStopTimesByNetexId() {
     return stopTimesByNetexId;
   }
 
   public void addStopTimesByNetexId(Map<String, StopTime> stopTimesByNetexId) {
-    this.stopTimesByNetexId.putAll(stopTimesByNetexId);
+    this.stopTimesByNetexId.addAll(stopTimesByNetexId);
   }
 
   public Multimap<String, DatedServiceJourney> getDatedServiceJourneysBySjId() {

--- a/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/support/NetexMapperIndexes.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Multimap;
 import java.util.Map;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.netex.index.api.NetexEntityIndexReadOnlyView;
+import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.transit.model.site.Station;
@@ -70,7 +71,7 @@ public class NetexMapperIndexes {
    * This is needed to assign a notice to a stop time. It is not part of the target
    * TransitDataImport, so we need to temporally cache this here.
    */
-  public HierarchicalMap<String, StopTime> getStopTimesByNetexId() {
+  public ReadOnlyHierarchicalMap<String, StopTime> getStopTimesByNetexId() {
     return stopTimesByNetexId;
   }
 

--- a/application/src/test/java/org/opentripplanner/netex/mapping/NetexMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/NetexMapperTest.java
@@ -3,6 +3,10 @@ package org.opentripplanner.netex.mapping;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.math.BigInteger;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.core.model.id.FeedScopedId;
@@ -13,18 +17,35 @@ import org.opentripplanner.netex.index.NetexEntityIndex;
 import org.opentripplanner.transit.model.framework.Deduplicator;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.service.SiteRepository;
+import org.rutebanken.netex.model.AllVehicleModesOfTransportEnumeration;
+import org.rutebanken.netex.model.JourneyPattern;
+import org.rutebanken.netex.model.JourneyPatternRefStructure;
+import org.rutebanken.netex.model.Line;
+import org.rutebanken.netex.model.LineRefStructure;
+import org.rutebanken.netex.model.MultilingualString;
+import org.rutebanken.netex.model.Notice;
+import org.rutebanken.netex.model.NoticeAssignment;
+import org.rutebanken.netex.model.PointInLinkSequence_VersionedChildStructure;
+import org.rutebanken.netex.model.PointsInJourneyPattern_RelStructure;
 import org.rutebanken.netex.model.Quay;
+import org.rutebanken.netex.model.Route;
+import org.rutebanken.netex.model.RouteRefStructure;
+import org.rutebanken.netex.model.ScheduledStopPointRefStructure;
+import org.rutebanken.netex.model.ServiceJourney;
+import org.rutebanken.netex.model.StopPointInJourneyPattern;
+import org.rutebanken.netex.model.StopPointInJourneyPatternRefStructure;
+import org.rutebanken.netex.model.TimetabledPassingTime;
+import org.rutebanken.netex.model.TimetabledPassingTimes_RelStructure;
+import org.rutebanken.netex.model.VersionOfObjectRefStructure;
 
 class NetexMapperTest {
 
   private static final String QUAY_ID = "quay-1";
   private static final String SSP_ID = "ssp-1";
   private static final String FEED_ID = "sta";
-  private static final RegularStop STOP = RegularStop.of(
-    new FeedScopedId(FEED_ID, QUAY_ID),
-    () -> 1
-  ).build();
+  private static final RegularStop STOP = stop(QUAY_ID);
   private static final Deduplicator DEDUPLICATOR = new Deduplicator();
+  private static final String TIMETABLED_PASSING_TIME_ID = "TTPT-1";
 
   @Test
   void sspWithAssignment() {
@@ -77,5 +98,137 @@ class NetexMapperTest {
     var issueTypes = issueStore.listIssues().stream().map(DataImportIssue::getType).toList();
 
     assertThat(issueTypes).contains("ScheduledStopPointAssignedToUnknownQuay");
+  }
+
+  /**
+   * {@link org.opentripplanner.netex.mapping.support.NetexMapperIndexes#getStopTimesByNetexId()}
+   * is documented to be scoped per hierarchy level (shared files, shared-group files, group
+   * files) and thrown away once that level is popped.
+   */
+  @Test
+  void noticeAssignmentIsNotResolvedAcrossSiblingFiles() {
+    var issueStore = new DefaultDataImportIssueStore();
+    var transitBuilder = new TransitDataImportBuilder(SiteRepository.of().build(), issueStore);
+    transitBuilder.siteRepository().withRegularStop(stop("quay-1"));
+    transitBuilder.siteRepository().withRegularStop(stop("quay-2"));
+
+    var netexMapper = new NetexMapper(
+      transitBuilder,
+      FEED_ID,
+      DEDUPLICATOR,
+      issueStore,
+      Set.of(),
+      Set.of(),
+      10,
+      false
+    );
+
+    // Level 0 ("shared data"): empty, but it is the common ancestor for both group files below.
+    netexMapper.mapNetexToOtp(new NetexEntityIndex().readOnlyView());
+
+    // Level 1 ("group"), file A: maps a ServiceJourney with a TimetabledPassingTime whose id is
+    // TIMETABLED_PASSING_TIME_ID.
+    netexMapper.push();
+    netexMapper.mapNetexToOtp(fileWithServiceJourney().readOnlyView());
+    netexMapper.pop();
+
+    // Level 1, file B: a sibling of file A (not a descendant of it), whose NoticeAssignment
+    // refers to the TimetabledPassingTime mapped while processing file A.
+    netexMapper.push();
+    netexMapper.mapNetexToOtp(fileWithNoticeAssignment(TIMETABLED_PASSING_TIME_ID).readOnlyView());
+    netexMapper.pop();
+
+    // If file A's StopTime had leaked into file B's lookup (the bug this guards against), the
+    // NoticeAssignment would have resolved successfully and none of these issues would be raised.
+    var issueTypes = issueStore.listIssues().stream().map(DataImportIssue::getType).toList();
+    assertThat(issueTypes).contains("NoticeAssignmentWithUnknownEntity");
+  }
+
+  private static RegularStop stop(String quayId) {
+    return RegularStop.of(new FeedScopedId(FEED_ID, quayId), () -> 1)
+      .withCoordinate(60.0, 10.0)
+      .build();
+  }
+
+  private static NetexEntityIndex fileWithServiceJourney() {
+    var index = new NetexEntityIndex();
+    index.timeZone.set("Europe/Oslo");
+
+    Line line = new Line()
+      .withId("RUT:Line:1")
+      .withName(new MultilingualString().withValue("Line 1"))
+      .withTransportMode(AllVehicleModesOfTransportEnumeration.BUS);
+    index.lineById.add(line);
+
+    var lineRef = MappingSupport.createWrappedRef(line.getId(), LineRefStructure.class);
+    index.routeById.add(new Route().withId("RUT:Route:1").withLineRef(lineRef));
+    var routeRef = new RouteRefStructure().withRef("RUT:Route:1");
+
+    List<PointInLinkSequence_VersionedChildStructure> points = new ArrayList<>();
+    List<TimetabledPassingTime> passingTimes = new ArrayList<>();
+    String[] quayIds = { "quay-1", "quay-2" };
+    String[] passingTimeIds = { TIMETABLED_PASSING_TIME_ID, "TTPT-2" };
+
+    for (int i = 0; i < quayIds.length; i++) {
+      String stopPointId = "RUT:StopPointInJourneyPattern:" + (i + 1);
+      points.add(
+        new StopPointInJourneyPattern()
+          .withId(stopPointId)
+          .withOrder(BigInteger.valueOf(i + 1))
+          .withScheduledStopPointRef(
+            MappingSupport.createWrappedRef(stopPointId, ScheduledStopPointRefStructure.class)
+          )
+      );
+      passingTimes.add(
+        new TimetabledPassingTime()
+          .withId(passingTimeIds[i])
+          .withDepartureTime(LocalTime.of(8, i))
+          .withPointInJourneyPatternRef(
+            MappingSupport.createWrappedRef(
+              stopPointId,
+              StopPointInJourneyPatternRefStructure.class
+            )
+          )
+      );
+      index.quayIdByStopPointRef.add(stopPointId, quayIds[i]);
+    }
+
+    var journeyPattern = new JourneyPattern()
+      .withId("RUT:JourneyPattern:1")
+      .withRouteRef(routeRef)
+      .withPointsInSequence(
+        new PointsInJourneyPattern_RelStructure().withPointInJourneyPatternOrStopPointInJourneyPatternOrTimingPointInJourneyPattern(
+          points
+        )
+      );
+    index.journeyPatternsById.add(journeyPattern);
+
+    var serviceJourney = new ServiceJourney()
+      .withId("RUT:ServiceJourney:1")
+      .withLineRef(lineRef)
+      .withJourneyPatternRef(
+        MappingSupport.createWrappedRef(journeyPattern.getId(), JourneyPatternRefStructure.class)
+      )
+      .withPassingTimes(
+        new TimetabledPassingTimes_RelStructure().withTimetabledPassingTime(passingTimes)
+      );
+    index.serviceJourneyById.add(serviceJourney);
+
+    return index;
+  }
+
+  private static NetexEntityIndex fileWithNoticeAssignment(String noticedObjectId) {
+    var index = new NetexEntityIndex();
+    var notice = new Notice()
+      .withId("RUT:Notice:1")
+      .withText(new MultilingualString().withValue("Notice text"));
+
+    var noticeAssignment = new NoticeAssignment()
+      .withId("RUT:NoticeAssignment:1")
+      .withNoticedObjectRef(new VersionOfObjectRefStructure().withRef(noticedObjectId))
+      .withNotice(notice);
+    index.noticeAssignmentById.add(noticeAssignment);
+
+    return index;
   }
 }

--- a/application/src/test/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/NoticeAssignmentMapperTest.java
@@ -4,12 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Multimap;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.graph_builder.issue.api.DataImportIssueStore;
 import org.opentripplanner.model.StopTime;
+import org.opentripplanner.netex.index.hierarchy.HierarchicalMap;
 import org.opentripplanner.netex.index.hierarchy.HierarchicalMapById;
 import org.opentripplanner.transit.model._data.TransitRepositoryForTest;
 import org.opentripplanner.transit.model.framework.AbstractTransitEntity;
@@ -59,7 +58,7 @@ public class NoticeAssignmentMapperTest {
       new HierarchicalMapById<>(),
       routesById,
       new DefaultEntityById<>(),
-      new HashMap<>()
+      new HierarchicalMap<>()
     );
 
     Multimap<
@@ -92,9 +91,9 @@ public class NoticeAssignmentMapperTest {
     StopTime stopTime1 = createStopTime(1, trip);
     StopTime stopTime2 = createStopTime(2, trip);
 
-    Map<String, StopTime> stopTimesById = new HashMap<>();
-    stopTimesById.put(TIMETABLED_PASSING_TIME1, stopTime1);
-    stopTimesById.put(TIMETABLED_PASSING_TIME2, stopTime2);
+    var stopTimesById = new HierarchicalMap<String, StopTime>();
+    stopTimesById.add(TIMETABLED_PASSING_TIME1, stopTime1);
+    stopTimesById.add(TIMETABLED_PASSING_TIME2, stopTime2);
 
     noticesById.add(NOTICE);
 


### PR DESCRIPTION
### Summary

Fixes a memory leak in the NeTEx import: `NetexMapperIndexes.stopTimesByNetexId` was aliased instead of copied at each level of the shared/group/file hierarchy, so it kept growing for the entire duration of the import instead of being scoped to (and thrown away with) each file level, as documented in the class's Javadoc. For a large feed such as Norway's national dataset this map ends up holding around 7 million `TimetabledPassingTime` → `StopTime` entries that are only ever needed within a single group file. This fix saves about 900MB of memory when building a graph from the Norwegian NeTEx bundle.

### Issue

https://github.com/noi-techpark/opendatahub-mentor-otp/issues/330

- **Motivation**: `NetexMapperIndexes` builds a tree of caches — one per shared file level, shared-group-file level, and individual group file — and its class Javadoc states the cache "is thrown away for each set of files loaded". `stopTimesByNetexId` didn't honor that: the constructor set `this.stopTimesByNetexId = parent.stopTimesByNetexId`, so every level in the tree referenced the exact same mutable `HashMap` as the root. Entries added while mapping one file (via `addStopTimesByNetexId`, called from `applyTripPatternMapperResult`) were never released, since the whole hierarchy shared one instance — the discard that happens on `pop()` had no effect on this particular field.
- **How the code works**: `stopTimesByNetexId` is used to attach `NoticeAssignment`s to the `StopTime`s produced while mapping `TimetabledPassingTime`s. A `NoticeAssignmentMapper` is built fresh for each level (see `NetexMapper#mapNoticeAssignments`) and looks up ids in the currently-scoped `stopTimesByNetexId`.

### Unit tests

I added a test but I feel it's a bit wordy. I would like to discuss if we also should have a module test framework for this part of the code.


### Memory saving

Before this PR I needed 4200MB of heap memory and afterwards I only need 3300MB.