### PR TITLE
Fix logging of JAXB type names

### DIFF
--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/NetexParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/NetexParser.java
@@ -53,7 +53,7 @@ abstract class NetexParser<T> {
     if (rel instanceof Collection) {
       throw new IllegalArgumentException("Do not pass in collections to this method.");
     }
-    log.warn("Netex import - Element mapping is missing for {}.", typeName(rel));
+    log.warn("Netex import - Element mapping is missing for {}.", resolveXmlTypeName(rel));
   }
 
   /* static methods for logging unhandled elements - this ensure consistent logging. */
@@ -68,7 +68,7 @@ abstract class NetexParser<T> {
     if (rel instanceof Collection) {
       throw new IllegalArgumentException("Do not pass in collections to this method.");
     }
-    log.info("Netex import - Element skipped: {}", typeName(rel));
+    log.info("Netex import - Element skipped: {}", resolveXmlTypeName(rel));
   }
 
   /** Perform parsing and keep the parsed objects internally. */
@@ -77,7 +77,13 @@ abstract class NetexParser<T> {
   /** Add the result - the parsed objects - to the index. */
   abstract void setResultOnIndex(NetexEntityIndex netexIndex);
 
-  private static String typeName(Object rel) {
+  /**
+   * Resolve the type name of the element for printing in the log.
+   * <p>
+   * Generally this is just the Java class name, but JAXB sometimes wraps them in a JAXBElement which
+   * would log as "JAXBElement". In such a case, the class name of the wrapped object is returned.
+   */
+  private static String resolveXmlTypeName(Object rel) {
     if (rel instanceof JAXBElement<?> jaxb) {
       return jaxb.getDeclaredType().getName();
     } else {

--- a/application/src/main/java/org/opentripplanner/netex/loader/parser/NetexParser.java
+++ b/application/src/main/java/org/opentripplanner/netex/loader/parser/NetexParser.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.netex.loader.parser;
 
+import jakarta.xml.bind.JAXBElement;
 import java.util.Collection;
 import org.opentripplanner.netex.index.NetexEntityIndex;
 import org.rutebanken.netex.model.VersionFrame_VersionStructure;
@@ -52,11 +53,10 @@ abstract class NetexParser<T> {
     if (rel instanceof Collection) {
       throw new IllegalArgumentException("Do not pass in collections to this method.");
     }
-    log.warn("Netex import - Element mapping is missing for {}.", rel.getClass().getName());
+    log.warn("Netex import - Element mapping is missing for {}.", typeName(rel));
   }
 
   /* static methods for logging unhandled elements - this ensure consistent logging. */
-
   /**
    * Unsupported elements are not relevant for Transit Routing, if you really think they should be
    * used in transit routing feel free to report an issue OTP GitHub.
@@ -68,7 +68,7 @@ abstract class NetexParser<T> {
     if (rel instanceof Collection) {
       throw new IllegalArgumentException("Do not pass in collections to this method.");
     }
-    log.info("Netex import - Element skipped: {}", rel.getClass().getName());
+    log.info("Netex import - Element skipped: {}", typeName(rel));
   }
 
   /** Perform parsing and keep the parsed objects internally. */
@@ -76,4 +76,12 @@ abstract class NetexParser<T> {
 
   /** Add the result - the parsed objects - to the index. */
   abstract void setResultOnIndex(NetexEntityIndex netexIndex);
+
+  private static String typeName(Object rel) {
+    if (rel instanceof JAXBElement<?> jaxb) {
+      return jaxb.getDeclaredType().getName();
+    } else {
+      return rel.getClass().getName();
+    }
+  }
 }


### PR DESCRIPTION
### Summary

When the NeTEx parser encountered an unknown JAXB element, then it would log the following:

```
14:10:06.016 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.017 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.018 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
14:10:06.018 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for jakarta.xml.bind.JAXBElement.
```

In order to get the proper XML type we need to make a small change to the logging code, so we get this

```
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.751 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.752 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ValueSet.
14:16:47.752 [WARN] (NetexParser.java:56) Netex import - Element mapping is missing for org.rutebanken.netex.model.ResponsibilitySetsInFrame_RelStructure.
```