### PR TITLE
Treat negative `stair_count` as stairs in `PathwayEdge`

### DIFF
--- a/street/src/main/java/org/opentripplanner/street/model/edge/PathwayEdge.java
+++ b/street/src/main/java/org/opentripplanner/street/model/edge/PathwayEdge.java
@@ -184,6 +184,6 @@ public class PathwayEdge extends Edge implements BikeWalkableEdge, WheelchairTra
   }
 
   private boolean isStairs() {
-    return steps > 0;
+    return steps != 0;
   }
 }

--- a/street/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
+++ b/street/src/test/java/org/opentripplanner/street/model/edge/PathwayEdgeTest.java
@@ -26,7 +26,8 @@ class PathwayEdgeTest {
 
   @Test
   void zeroLength() {
-    // if elevators have a traversal time and distance of 0 we cannot interpolate the distance
+    // if elevators have a traversal time and distance of 0 we cannot interpolate
+    // the distance
     // from the vertices as they most likely have identical coordinates
     var edge = PathwayEdge.createPathwayEdge(
       from,
@@ -132,6 +133,35 @@ class PathwayEdgeTest {
     assertEquals(300.0, state.getWeight());
   }
 
+  @Test
+  void wheelchairNegativeStepsTreatedAsStairs() {
+    var down = PathwayEdge.createPathwayEdge(
+      from,
+      to,
+      new NonLocalizedString("pathway"),
+      0,
+      0,
+      -10,
+      0,
+      true
+    );
+    var up = PathwayEdge.createPathwayEdge(
+      from,
+      to,
+      new NonLocalizedString("pathway"),
+      0,
+      0,
+      10,
+      0,
+      true
+    );
+
+    var downState = assertThatEdgeIsTraversable(down, true);
+    var upState = assertThatEdgeIsTraversable(up, true);
+
+    assertEquals(upState.getWeight(), downState.getWeight());
+  }
+
   static Stream<Arguments> slopeCases() {
     return Stream.of(
       // no extra cost
@@ -150,10 +180,13 @@ class PathwayEdgeTest {
   }
 
   /**
-   * This makes sure that when you exceed the max slope in a wheelchair there isn't a hard cut-off
-   * but rather the cost increases proportional to how much you go over the maximum.
+   * This makes sure that when you exceed the max slope in a wheelchair there
+   * isn't a hard cut-off
+   * but rather the cost increases proportional to how much you go over the
+   * maximum.
    * <p>
-   * In other words: 0.1 % over the limit only has a small cost but 2% over increases it
+   * In other words: 0.1 % over the limit only has a small cost but 2% over
+   * increases it
    * dramatically to the point where it's only used as a last resort.
    */
   @ParameterizedTest(name = "slope of {0} should lead to traversal costs of {1}")


### PR DESCRIPTION
### Summary

Fixes routing cost calculations for GTFS pathways with negative `stair_count` by correctly treating them as stairs in `PathwayEdge`.

### Issue

GTFS pathways allow negative values in `stair_count` to represent descending stairs. Previously, `PathwayEdge.isStairs()` checked `steps > 0`, ignoring descending staircases and causing routing costs to ignore stair reluctance for negative step counts. 

Updating `isStairs()` to check `steps != 0` ensures both ascending and descending stairs apply appropriate routing costs and reluctance penalties.

Closes #7914

### Unit tests

- Updated `wheelchairNegativeStepsTreatedAsStairs` unit test in `PathwayEdgeTest.java` to verify that negative steps carry the same reluctance/weight as positive steps.
- All unit tests pass locally (`mvn test -pl street`).