### PR TITLE
Remove UnusedImports checkstyle rule

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -20,7 +20,6 @@
         <module name="TrailingComment">
             <property name="format" value="^\s*$"/>
         </module>
-        <module name="UnusedImports"/>
         <module name="UnusedLocalVariable"/>
         <module name="PackageDeclaration">
             <property name="matchDirectoryStructure" value="true"/>


### PR DESCRIPTION
### Summary

`UnusedImports` is now handled by Spotless so having it still in checkstyle rules as well just caused unnecessary checkstyle errors in Intellij when using checkstyle plugin.

### Issue

No issue

### Unit tests

No

### Documentation

No

### Changelog

No
