### PR TITLE
Expand {from}/{to} placeholders in the carpool booking URL

### DIFF
--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolBookingUrlTestData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolBookingUrlTestData.java
@@ -4,35 +4,53 @@ import java.util.Locale;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 
 /**
- * Shared expected-URL formatter for tests that assert the carpool booking URL has been augmented
- * with passenger pickup/dropoff coordinates. Centralised so the production
- * {@code "from_coordinate=lat,lon&to_coordinate=lat,lon"} contract — coordinate precision,
- * parameter names, and ordering — is pinned down in one place that all
+ * Shared booking-URL template and its expected expansion, for tests asserting that the carpool
+ * booking URL has had the passenger's pickup/dropoff coordinates expanded into it. Centralised so
+ * the production contract — the {@code {from}}/{@code {to}} placeholder spelling and the
+ * {@code "latitude,longitude"} rendering at six decimals — is pinned down in one place that all
  * {@code CarpoolItineraryMapper} tests assert against.
+ * <p>
+ * The query parameter names carrying the placeholders ({@code from_coordinate},
+ * {@code to_coordinate}) are the provider's own choice and form no part of OTP's contract; they
+ * are here only to make the template realistic.
  */
 public final class CarpoolBookingUrlTestData {
 
   private CarpoolBookingUrlTestData() {}
 
   /**
-   * Returns the booking URL that {@code CarpoolItineraryMapper.toBookingInfo} is expected to
-   * produce when augmenting {@code baseUrl} with the given carpool boarding ({@code pickup}) and
-   * alighting ({@code dropoff}) coordinates. Assumes {@code baseUrl} carries no existing query
-   * string and no fragment.
+   * Returns {@code baseUrl} with a query string carrying both placeholders — the shape of booking
+   * URL a carpool provider publishes in order to receive the passenger's coordinates.
    */
-  public static String expectedAugmentedUrl(
+  public static String bookingUrlTemplate(String baseUrl) {
+    return baseUrl + "?from_coordinate={from}&to_coordinate={to}";
+  }
+
+  /**
+   * Returns the {@code "latitude,longitude"} rendering that a {@code {from}} or {@code {to}}
+   * placeholder is expected to expand to. The single place test code spells this format out, so
+   * that a change of precision has one place to be updated on the test side.
+   */
+  public static String expandedCoordinate(WgsCoordinate coordinate) {
+    return String.format(Locale.ROOT, "%.6f,%.6f", coordinate.latitude(), coordinate.longitude());
+  }
+
+  /**
+   * Returns the URL that {@code CarpoolItineraryMapper.toBookingInfo} is expected to produce from
+   * {@link #bookingUrlTemplate(String)} for the given carpool boarding ({@code pickup}) and
+   * alighting ({@code dropoff}) coordinates.
+   */
+  public static String expectedExpandedUrl(
     String baseUrl,
     WgsCoordinate pickup,
     WgsCoordinate dropoff
   ) {
-    return String.format(
-      Locale.ROOT,
-      "%s?from_coordinate=%.6f,%.6f&to_coordinate=%.6f,%.6f",
-      baseUrl,
-      pickup.latitude(),
-      pickup.longitude(),
-      dropoff.latitude(),
-      dropoff.longitude()
+    return (
+      baseUrl +
+      "?from_coordinate=" +
+      expandedCoordinate(pickup) +
+      "&to_coordinate=" +
+      expandedCoordinate(dropoff)
     );
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolBookingUrlTestData.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/CarpoolBookingUrlTestData.java
@@ -7,8 +7,8 @@ import org.opentripplanner.street.geometry.WgsCoordinate;
  * Shared booking-URL template and its expected expansion, for tests asserting that the carpool
  * booking URL has had the passenger's pickup/dropoff coordinates expanded into it. Centralised so
  * the production contract — the {@code {from}}/{@code {to}} placeholder spelling and the
- * {@code "latitude,longitude"} rendering at six decimals — is pinned down in one place that all
- * {@code CarpoolItineraryMapper} tests assert against.
+ * {@code "latitude,longitude"} rendering at six decimals — is pinned down in one place that the
+ * mapper and service tests assert against.
  * <p>
  * The query parameter names carrying the placeholders ({@code from_coordinate},
  * {@code to_coordinate}) are the provider's own choice and form no part of OTP's contract; they

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
@@ -3,7 +3,9 @@ package org.opentripplanner.ext.carpooling.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedAugmentedUrl;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.bookingUrlTemplate;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expandedCoordinate;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedExpandedUrl;
 import static org.opentripplanner.ext.carpooling.CarpoolGraphPathBuilder.createGraphPath;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_NORTH;
@@ -15,7 +17,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Locale;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.opentripplanner.astar.model.GraphPath;
@@ -66,6 +67,10 @@ class CarpoolItineraryMapperTest {
 
   private static final WgsCoordinate PICKUP = new WgsCoordinate(59.910000, 10.750000);
   private static final WgsCoordinate DROPOFF = new WgsCoordinate(59.920000, 10.760000);
+
+  /** What {@code {from}} and {@code {to}} expand to for {@link #PICKUP} / {@link #DROPOFF}. */
+  private static final String PICKUP_COORD = expandedCoordinate(PICKUP);
+  private static final String DROPOFF_COORD = expandedCoordinate(DROPOFF);
 
   private static final Duration STOP_DURATION = Duration.ofMinutes(2);
   private static final int PICKUP_POSITION = 1;
@@ -125,48 +130,106 @@ class CarpoolItineraryMapperTest {
   }
 
   @Test
-  void urlOnly_addsOnlineAndAppendsPickupAndDropoffCoordinatesToUrl() {
-    var contact = ContactInfo.of().withBookingUrl("https://book.example.com").build();
+  void urlOnly_addsOnlineAndExpandsPickupAndDropoffCoordinatesIntoUrl() {
+    var contact = ContactInfo.of()
+      .withBookingUrl(bookingUrlTemplate("https://book.example.com"))
+      .build();
 
     var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
 
     assertNotNull(info);
     assertEquals(EnumSet.of(BookingMethod.ONLINE), info.bookingMethods());
     assertEquals(
-      expectedAugmentedUrl("https://book.example.com", PICKUP, DROPOFF),
+      expectedExpandedUrl("https://book.example.com", PICKUP, DROPOFF),
       info.getContactInfo().getBookingUrl()
     );
   }
 
   /**
-   * Guards against the easy bug of unconditionally appending {@code ?from_coordinate=…}, which
-   * would yield an invalid double-{@code ?} URL when the provider's booking URL already carries
-   * its own query string (e.g. tracking parameters). The coordinate parameters must be appended
-   * with {@code &} in that case.
+   * A booking URL carrying neither placeholder is the provider declining to receive the
+   * passenger's coordinates, so the URL must reach the API byte-for-byte as published — no
+   * coordinate parameters invented on the provider's behalf, and no normalisation applied by the
+   * {@link java.net.URI} round-trip that validates it.
    */
   @Test
-  void urlWithExistingQueryString_usesAmpersandSeparator() {
-    var contact = ContactInfo.of().withBookingUrl("https://book.example.com/?ref=foo").build();
+  void urlWithoutPlaceholders_isPassedThroughUnchanged() {
+    var url = "https://book.example.com/trip/42?ref=foo#bookform";
+    var contact = ContactInfo.of().withBookingUrl(url).build();
 
     var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
 
     assertNotNull(info);
-    var expected = String.format(
-      Locale.ROOT,
-      "https://book.example.com/?ref=foo&from_coordinate=%.6f,%.6f&to_coordinate=%.6f,%.6f",
-      PICKUP.latitude(),
-      PICKUP.longitude(),
-      DROPOFF.latitude(),
-      DROPOFF.longitude()
+    assertEquals(EnumSet.of(BookingMethod.ONLINE), info.bookingMethods());
+    assertEquals(url, info.getContactInfo().getBookingUrl());
+  }
+
+  /**
+   * The two placeholders are independent: a provider wanting only the pickup publishes only
+   * {@code {from}}, and the rest of its URL — including a query that never mentions
+   * {@code {to}} — must survive untouched.
+   */
+  @Test
+  void urlWithOnlyFromPlaceholder_expandsItAndLeavesTheRestAlone() {
+    var contact = ContactInfo.of()
+      .withBookingUrl("https://book.example.com/trip/42?pickup={from}&ref=foo")
+      .build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
+
+    assertNotNull(info);
+    assertEquals(
+      "https://book.example.com/trip/42?pickup=" + PICKUP_COORD + "&ref=foo",
+      info.getContactInfo().getBookingUrl()
     );
-    assertEquals(expected, info.getContactInfo().getBookingUrl());
+  }
+
+  /**
+   * Placeholders are expanded wherever the provider puts them — path segment, query or fragment,
+   * a single-page booking app routing on the {@code #fragment} included — and at every
+   * occurrence, because expansion is a plain substitution on the published URL rather than a
+   * rebuild of the URI's components.
+   */
+  @Test
+  void placeholders_areExpandedInEveryComponentAndAtEveryOccurrence() {
+    var contact = ContactInfo.of()
+      .withBookingUrl("https://book.example.com/book/{from}/to/{to}?pickup={from}#at/{to}")
+      .build();
+
+    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
+
+    assertNotNull(info);
+    assertEquals(
+      "https://book.example.com/book/" +
+        PICKUP_COORD +
+        "/to/" +
+        DROPOFF_COORD +
+        "?pickup=" +
+        PICKUP_COORD +
+        "#at/" +
+        DROPOFF_COORD,
+      info.getContactInfo().getBookingUrl()
+    );
+  }
+
+  /**
+   * Placeholder names are case-sensitive, so {@code {From}} is not expanded and its leftover
+   * braces get the URL dropped along with {@link BookingMethod#ONLINE}, rather than handed to the
+   * user with a literal {@code {From}} in it.
+   */
+  @Test
+  void urlWithUnrecognisedPlaceholder_dropsUrl() {
+    var contact = ContactInfo.of()
+      .withBookingUrl("https://book.example.com/trip/42?pickup={From}")
+      .build();
+
+    assertNull(CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF));
   }
 
   @Test
   void phoneAndUrl_addsBothMethodsAndOnlyRewritesUrl() {
     var contact = ContactInfo.of()
       .withPhoneNumber("+4712345678")
-      .withBookingUrl("https://book.example.com")
+      .withBookingUrl(bookingUrlTemplate("https://book.example.com"))
       .build();
 
     var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
@@ -176,36 +239,12 @@ class CarpoolItineraryMapperTest {
       EnumSet.of(BookingMethod.CALL_OFFICE, BookingMethod.ONLINE),
       info.bookingMethods()
     );
-    var augmented = info.getContactInfo();
-    assertEquals("+4712345678", augmented.getPhoneNumber());
+    var expanded = info.getContactInfo();
+    assertEquals("+4712345678", expanded.getPhoneNumber());
     assertEquals(
-      expectedAugmentedUrl("https://book.example.com", PICKUP, DROPOFF),
-      augmented.getBookingUrl()
+      expectedExpandedUrl("https://book.example.com", PICKUP, DROPOFF),
+      expanded.getBookingUrl()
     );
-  }
-
-  /**
-   * Pins down the URL with a {@code #fragment}: the appended coordinate parameters must end up
-   * in the query (before the fragment), not inside the fragment. The string-level
-   * {@code url.contains("?")} predicate doesn't catch this — switching to {@link java.net.URI}
-   * parsing does, because the fragment is split off the URL before it can swallow the params.
-   */
-  @Test
-  void urlWithFragment_appendsParamsBeforeFragment() {
-    var contact = ContactInfo.of().withBookingUrl("https://book.example.com/page#bookform").build();
-
-    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
-
-    assertNotNull(info);
-    var expected = String.format(
-      Locale.ROOT,
-      "https://book.example.com/page?from_coordinate=%.6f,%.6f&to_coordinate=%.6f,%.6f#bookform",
-      PICKUP.latitude(),
-      PICKUP.longitude(),
-      DROPOFF.latitude(),
-      DROPOFF.longitude()
-    );
-    assertEquals(expected, info.getContactInfo().getBookingUrl());
   }
 
   /**

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapperTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.bookingUrlTemplate;
-import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expandedCoordinate;
 import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedExpandedUrl;
 import static org.opentripplanner.ext.carpooling.CarpoolGraphPathBuilder.createGraphPath;
 import static org.opentripplanner.ext.carpooling.CarpoolTestCoordinates.OSLO_CENTER;
@@ -67,10 +66,6 @@ class CarpoolItineraryMapperTest {
 
   private static final WgsCoordinate PICKUP = new WgsCoordinate(59.910000, 10.750000);
   private static final WgsCoordinate DROPOFF = new WgsCoordinate(59.920000, 10.760000);
-
-  /** What {@code {from}} and {@code {to}} expand to for {@link #PICKUP} / {@link #DROPOFF}. */
-  private static final String PICKUP_COORD = expandedCoordinate(PICKUP);
-  private static final String DROPOFF_COORD = expandedCoordinate(DROPOFF);
 
   private static final Duration STOP_DURATION = Duration.ofMinutes(2);
   private static final int PICKUP_POSITION = 1;
@@ -145,86 +140,6 @@ class CarpoolItineraryMapperTest {
     );
   }
 
-  /**
-   * A booking URL carrying neither placeholder is the provider declining to receive the
-   * passenger's coordinates, so the URL must reach the API byte-for-byte as published — no
-   * coordinate parameters invented on the provider's behalf, and no normalisation applied by the
-   * {@link java.net.URI} round-trip that validates it.
-   */
-  @Test
-  void urlWithoutPlaceholders_isPassedThroughUnchanged() {
-    var url = "https://book.example.com/trip/42?ref=foo#bookform";
-    var contact = ContactInfo.of().withBookingUrl(url).build();
-
-    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
-
-    assertNotNull(info);
-    assertEquals(EnumSet.of(BookingMethod.ONLINE), info.bookingMethods());
-    assertEquals(url, info.getContactInfo().getBookingUrl());
-  }
-
-  /**
-   * The two placeholders are independent: a provider wanting only the pickup publishes only
-   * {@code {from}}, and the rest of its URL — including a query that never mentions
-   * {@code {to}} — must survive untouched.
-   */
-  @Test
-  void urlWithOnlyFromPlaceholder_expandsItAndLeavesTheRestAlone() {
-    var contact = ContactInfo.of()
-      .withBookingUrl("https://book.example.com/trip/42?pickup={from}&ref=foo")
-      .build();
-
-    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
-
-    assertNotNull(info);
-    assertEquals(
-      "https://book.example.com/trip/42?pickup=" + PICKUP_COORD + "&ref=foo",
-      info.getContactInfo().getBookingUrl()
-    );
-  }
-
-  /**
-   * Placeholders are expanded wherever the provider puts them — path segment, query or fragment,
-   * a single-page booking app routing on the {@code #fragment} included — and at every
-   * occurrence, because expansion is a plain substitution on the published URL rather than a
-   * rebuild of the URI's components.
-   */
-  @Test
-  void placeholders_areExpandedInEveryComponentAndAtEveryOccurrence() {
-    var contact = ContactInfo.of()
-      .withBookingUrl("https://book.example.com/book/{from}/to/{to}?pickup={from}#at/{to}")
-      .build();
-
-    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
-
-    assertNotNull(info);
-    assertEquals(
-      "https://book.example.com/book/" +
-        PICKUP_COORD +
-        "/to/" +
-        DROPOFF_COORD +
-        "?pickup=" +
-        PICKUP_COORD +
-        "#at/" +
-        DROPOFF_COORD,
-      info.getContactInfo().getBookingUrl()
-    );
-  }
-
-  /**
-   * Placeholder names are case-sensitive, so {@code {From}} is not expanded and its leftover
-   * braces get the URL dropped along with {@link BookingMethod#ONLINE}, rather than handed to the
-   * user with a literal {@code {From}} in it.
-   */
-  @Test
-  void urlWithUnrecognisedPlaceholder_dropsUrl() {
-    var contact = ContactInfo.of()
-      .withBookingUrl("https://book.example.com/trip/42?pickup={From}")
-      .build();
-
-    assertNull(CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF));
-  }
-
   @Test
   void phoneAndUrl_addsBothMethodsAndOnlyRewritesUrl() {
     var contact = ContactInfo.of()
@@ -245,42 +160,6 @@ class CarpoolItineraryMapperTest {
       expectedExpandedUrl("https://book.example.com", PICKUP, DROPOFF),
       expanded.getBookingUrl()
     );
-  }
-
-  /**
-   * When the booking URL is unparseable, the URL is dropped from the contact and
-   * {@link BookingMethod#ONLINE} is removed from the booking methods rather than left in place
-   * pointing nowhere. If the contact carried only the (now-dropped) URL, no actionable booking
-   * method remains and {@code toBookingInfo} returns {@code null}, matching the
-   * "non-null return ⇒ at least one usable method" contract.
-   */
-  @Test
-  void malformedUrlOnly_returnsNull() {
-    var contact = ContactInfo.of().withBookingUrl("https://book.example.com/has space").build();
-
-    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
-
-    assertNull(info);
-  }
-
-  /**
-   * Same malformed-URL handling as {@link #malformedUrlOnly_returnsNull()} but with a phone
-   * number also present: the call-office method survives, the dropped URL is reflected as
-   * {@code null} on the returned contact, and {@code ONLINE} is absent from the booking methods.
-   */
-  @Test
-  void malformedUrlWithPhone_keepsCallOfficeAndDropsUrl() {
-    var contact = ContactInfo.of()
-      .withPhoneNumber("+4712345678")
-      .withBookingUrl("https://book.example.com/has space")
-      .build();
-
-    var info = CarpoolItineraryMapper.toBookingInfo(contact, TRIP_START, PICKUP, DROPOFF);
-
-    assertNotNull(info);
-    assertEquals(EnumSet.of(BookingMethod.CALL_OFFICE), info.bookingMethods());
-    assertEquals("+4712345678", info.getContactInfo().getPhoneNumber());
-    assertNull(info.getContactInfo().getBookingUrl());
   }
 
   /**

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceAccessEgressTest.java
@@ -5,7 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedAugmentedUrl;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.bookingUrlTemplate;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedExpandedUrl;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -770,12 +771,12 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
    * walking endpoint ({@code T5}), and equally not the driver's trip origin ({@code A}).
    */
   @Test
-  void accessItinerary_appendsCarpoolBoardingAndAlightingCoords_notWalkLegCoords() {
+  void accessItinerary_expandsCarpoolBoardingAndAlightingCoords_notWalkLegCoords() {
     var departureTime = SEARCH_TIME.plusMinutes(30);
     var baseTrip = CarpoolTripTestData.createSimpleTripWithTime(coordA, coordD, departureTime);
     var trip = new CarpoolTripBuilder(baseTrip)
       .withPublicContactInformation(
-        ContactInfo.of().withBookingUrl("https://book.example.com").build()
+        ContactInfo.of().withBookingUrl(bookingUrlTemplate("https://book.example.com")).build()
       )
       .build();
     context.upsertTrip(trip);
@@ -821,7 +822,7 @@ class DefaultCarpoolingServiceAccessEgressTest extends GraphRoutingTest {
     assertNotNull(bookingInfo);
 
     assertEquals(
-      expectedAugmentedUrl(
+      expectedExpandedUrl(
         "https://book.example.com",
         carpoolLeg.from().coordinate,
         carpoolLeg.to().coordinate

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceDirectTest.java
@@ -5,7 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedAugmentedUrl;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.bookingUrlTemplate;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedExpandedUrl;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -407,21 +408,21 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
   }
 
   /**
-   * Verifies that the booking URL on the carpool leg is augmented with {@code from_coordinate}
-   * and {@code to_coordinate} query parameters reflecting the passenger's carpool boarding and
-   * alighting points. In this graph the passenger's requested pickup is itself a graph vertex
+   * Verifies that the booking URL template on the carpool leg has its {@code {from}} and
+   * {@code {to}} placeholders expanded with the passenger's carpool boarding and alighting
+   * points. In this graph the passenger's requested pickup is itself a graph vertex
    * (P) and the carpool ride goes P → Q, so the URL coordinates equal P/Q (which are also the
    * passenger's request endpoints here — distinguishing them from a separate walk leg is the job
    * of {@link DefaultCarpoolingServiceWalkLegsTest}). The exact-equality assertion also pins
    * down that the URL does NOT use the driver's origin (A) or destination (D).
    */
   @Test
-  void directItinerary_appendsCarpoolPickupAndDropoffCoordsToBookingUrl() {
+  void directItinerary_expandsCarpoolPickupAndDropoffCoordsIntoBookingUrl() {
     var departureTime = SEARCH_TIME.plusMinutes(10);
     var baseTrip = CarpoolTripTestData.createSimpleTripWithTime(tripStart, tripEnd, departureTime);
     var trip = new CarpoolTripBuilder(baseTrip)
       .withPublicContactInformation(
-        ContactInfo.of().withBookingUrl("https://book.example.com").build()
+        ContactInfo.of().withBookingUrl(bookingUrlTemplate("https://book.example.com")).build()
       )
       .build();
     context.upsertTrip(trip);
@@ -434,7 +435,7 @@ class DefaultCarpoolingServiceDirectTest extends GraphRoutingTest {
     assertNotNull(bookingInfo);
 
     assertEquals(
-      expectedAugmentedUrl("https://book.example.com", passengerPickup, passengerDropoff),
+      expectedExpandedUrl("https://book.example.com", passengerPickup, passengerDropoff),
       bookingInfo.getContactInfo().getBookingUrl()
     );
   }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/service/DefaultCarpoolingServiceWalkLegsTest.java
@@ -4,7 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedAugmentedUrl;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.bookingUrlTemplate;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expectedExpandedUrl;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -257,7 +258,7 @@ class DefaultCarpoolingServiceWalkLegsTest extends GraphRoutingTest {
   }
 
   /**
-   * Verifies that {@code from_coordinate} / {@code to_coordinate} on the booking URL reference the
+   * Verifies that the {@code {from}} / {@code {to}} placeholders on the booking URL expand to the
    * carpool boarding/alighting vertices (B and C — where the passenger actually gets in and out
    * of the car) and NOT the passenger's walking endpoints (P and Q). This is the case the user's
    * spec explicitly called out: the coordinates must not be where the passenger starts/finishes
@@ -273,7 +274,7 @@ class DefaultCarpoolingServiceWalkLegsTest extends GraphRoutingTest {
     );
     var trip = new CarpoolTripBuilder(baseTrip)
       .withPublicContactInformation(
-        ContactInfo.of().withBookingUrl("https://book.example.com").build()
+        ContactInfo.of().withBookingUrl(bookingUrlTemplate("https://book.example.com")).build()
       )
       .build();
     context.upsertTrip(trip);
@@ -286,7 +287,7 @@ class DefaultCarpoolingServiceWalkLegsTest extends GraphRoutingTest {
     assertNotNull(bookingInfo);
 
     assertEquals(
-      expectedAugmentedUrl("https://book.example.com", B_COORD, C_COORD),
+      expectedExpandedUrl("https://book.example.com", B_COORD, C_COORD),
       bookingInfo.getContactInfo().getBookingUrl()
     );
   }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapperTest.java
@@ -31,6 +31,8 @@ import static org.opentripplanner.ext.carpooling.model.CarpoolTrip.DEFAULT_TOTAL
 import java.time.Duration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.org.siri.siri21.EstimatedCall;
 
 public class CarpoolSiriMapperTest {
@@ -312,11 +314,42 @@ public class CarpoolSiriMapperTest {
     assertEquals("https://example.com/book", mapped.publicContactInformation().getBookingUrl());
   }
 
+  /** A template reaches the trip as published: validation must not expand its placeholders. */
+  @Test
+  void mapSiriToCarpoolTrip_withBookingUrlTemplate_keepsThePlaceholdersVerbatim() {
+    var template = "https://example.com/book?pickup={from}&dropoff={to}";
+    var mapped = mapper.mapSiriToCarpoolTrip(journeyWithPublicContact(null, template));
+
+    assertNotNull(mapped.publicContactInformation());
+    assertEquals(template, mapped.publicContactInformation().getBookingUrl());
+  }
+
   @Test
   void mapSiriToCarpoolTrip_withoutPublicContact_contactInformationIsNull() {
     var journey = minimalCompleteJourney();
     var mapped = mapper.mapSiriToCarpoolTrip(journey);
 
+    assertNull(mapped.publicContactInformation());
+  }
+
+  /** An unusable URL costs the trip its URL and nothing more. */
+  @ParameterizedTest
+  @ValueSource(strings = { "https://example.com/book?pickup={From}", "https://example.com/a b" })
+  void mapSiriToCarpoolTrip_withUnusableBookingUrl_dropsTheUrl(String bookingUrl) {
+    var mapped = mapper.mapSiriToCarpoolTrip(journeyWithPublicContact("+4712345678", bookingUrl));
+
+    assertNotNull(mapped.publicContactInformation());
+    assertNull(mapped.publicContactInformation().getBookingUrl());
+    assertEquals("+4712345678", mapped.publicContactInformation().getPhoneNumber());
+  }
+
+  /** A trip whose only contact channel is an unusable URL is kept, without contact details. */
+  @Test
+  void mapSiriToCarpoolTrip_withOnlyAnUnusableBookingUrl_contactInformationIsNull() {
+    var journey = journeyWithPublicContact(null, "https://example.com/a b");
+    var mapped = mapper.mapSiriToCarpoolTrip(journey);
+
+    assertNotNull(mapped);
     assertNull(mapped.publicContactInformation());
   }
 }

--- a/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/BookingUrlTemplateTest.java
+++ b/application/src/ext-test/java/org/opentripplanner/ext/carpooling/util/BookingUrlTemplateTest.java
@@ -1,0 +1,82 @@
+package org.opentripplanner.ext.carpooling.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opentripplanner.ext.carpooling.CarpoolBookingUrlTestData.expandedCoordinate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+
+class BookingUrlTemplateTest {
+
+  private static final WgsCoordinate PICKUP = new WgsCoordinate(59.910000, 10.750000);
+  private static final WgsCoordinate DROPOFF = new WgsCoordinate(59.920000, 10.760000);
+
+  private static final String PICKUP_COORD = expandedCoordinate(PICKUP);
+  private static final String DROPOFF_COORD = expandedCoordinate(DROPOFF);
+
+  @Test
+  void rendersCoordinateAsLatitudeCommaLongitudeAtSixDecimals() {
+    assertEquals(
+      "https://book.example.com/?pickup=59.910000,10.750000",
+      expand("https://book.example.com/?pickup={from}")
+    );
+  }
+
+  /** A provider wanting only the pickup publishes only {@code {from}}; the rest is untouched. */
+  @Test
+  void leavesTheRestOfTheUrlAlone() {
+    assertEquals(
+      "https://book.example.com/trip/42?pickup=" + PICKUP_COORD + "&ref=foo",
+      expand("https://book.example.com/trip/42?pickup={from}&ref=foo")
+    );
+  }
+
+  /** Placeholders are expanded wherever they appear, and at every occurrence. */
+  @Test
+  void expandsEveryComponentAndEveryOccurrence() {
+    assertEquals(
+      "https://book.example.com/book/" +
+        PICKUP_COORD +
+        "/to/" +
+        DROPOFF_COORD +
+        "?pickup=" +
+        PICKUP_COORD +
+        "#at/" +
+        DROPOFF_COORD,
+      expand("https://book.example.com/book/{from}/to/{to}?pickup={from}#at/{to}")
+    );
+  }
+
+  @Test
+  void passesAUrlWithoutPlaceholdersThroughUnchanged() {
+    var url = "https://book.example.com/trip/42?ref=foo#bookform";
+
+    assertEquals(url, expand(url));
+    assertTrue(BookingUrlTemplate.isUsable(url));
+  }
+
+  @Test
+  void acceptsATemplate() {
+    assertTrue(BookingUrlTemplate.isUsable("https://book.example.com/book/{from}?dropoff={to}"));
+  }
+
+  /**
+   * A misspelled {@code {From}} is not expanded, and its surviving braces are not legal URI
+   * characters — as a stray space is not.
+   */
+  @ParameterizedTest
+  @ValueSource(
+    strings = { "https://book.example.com/trip/42?pickup={From}", "https://book.example.com/a b" }
+  )
+  void rejectsWhatIsNotAUri(String urlTemplate) {
+    assertFalse(BookingUrlTemplate.isUsable(urlTemplate), urlTemplate);
+  }
+
+  private static String expand(String urlTemplate) {
+    return BookingUrlTemplate.expand(urlTemplate, PICKUP, DROPOFF);
+  }
+}

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
@@ -1,12 +1,9 @@
 package org.opentripplanner.ext.carpooling.internal;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.locationtech.jts.geom.LineString;
@@ -19,6 +16,7 @@ import org.opentripplanner.ext.carpooling.model.CarpoolLeg;
 import org.opentripplanner.ext.carpooling.routing.CarpoolAccessEgress;
 import org.opentripplanner.ext.carpooling.routing.EndpointLabel;
 import org.opentripplanner.ext.carpooling.routing.InsertionCandidate;
+import org.opentripplanner.ext.carpooling.util.BookingUrlTemplate;
 import org.opentripplanner.model.GenericLocation;
 import org.opentripplanner.model.plan.Itinerary;
 import org.opentripplanner.model.plan.Leg;
@@ -38,8 +36,6 @@ import org.opentripplanner.transit.model.timetable.booking.BookingInfo;
 import org.opentripplanner.transit.model.timetable.booking.BookingMethod;
 import org.opentripplanner.transit.model.timetable.booking.BookingTime;
 import org.opentripplanner.utils.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Maps carpooling insertion candidates to OTP itineraries for API responses.
@@ -98,7 +94,6 @@ import org.slf4j.LoggerFactory;
  */
 public class CarpoolItineraryMapper {
 
-  private static final Logger LOG = LoggerFactory.getLogger(CarpoolItineraryMapper.class);
   private static final I18NString ORIGIN_DEFAULT_NAME = new LocalizedString("origin");
   private static final I18NString DESTINATION_DEFAULT_NAME = new LocalizedString("destination");
 
@@ -296,20 +291,9 @@ public class CarpoolItineraryMapper {
   /**
    * Builds the carpool leg's {@code pickupBookingInfo} from the trip's public-contact details.
    * <p>
-   * The contact's {@code bookingUrl} (if present) is treated as a URI template: its
+   * The contact's {@code bookingUrl} (if present) is a {@link BookingUrlTemplate}: its
    * {@code {from}} and {@code {to}} placeholders are expanded with the passenger's carpool
    * boarding and alighting vertices — i.e. where the passenger gets in/out of the driver's car.
-   * These are distinct from the passenger's walking endpoints (handled by the surrounding walk
-   * legs) and from the driver's trip origin/destination. See
-   * {@link #expandPassengerCoordinates(String, WgsCoordinate, WgsCoordinate)} for the template
-   * syntax and for the treatment of a URL that carries no placeholders.
-   * <p>
-   * If the booking URL is not a valid {@link URI} once its placeholders have been expanded, the
-   * URL is dropped from the returned {@code BookingInfo} (the failure is logged and the trip is
-   * treated as if it published no booking URL at all) and {@link BookingMethod#ONLINE} is omitted
-   * from the booking methods. This keeps the "non-null return ⇒ at least one usable booking
-   * method" contract honest: a {@code BookingInfo} is never returned advertising {@code ONLINE}
-   * without a URL the user can actually open.
    * <p>
    * {@code latestBookingTime} is a temporary placeholder: how a real booking deadline should be
    * sourced for carpool trips is yet to be decided, so it is approximated by the trip's
@@ -329,11 +313,10 @@ public class CarpoolItineraryMapper {
    * @param dropoff the carpool alighting coordinate (where the passenger gets out of the car),
    *        expanded into the booking URL's {@code {to}} placeholder.
    * @return a booking info populated with the contact details and derived booking methods
-   *         (CALL_OFFICE if phone is set, ONLINE if URL is set and parses), or {@code null} when
+   *         (CALL_OFFICE if phone is set, ONLINE if a booking URL is set), or {@code null} when
    *         no actionable booking method can be derived — i.e. {@code contact} is {@code null},
-   *         the contact carries neither a phone number nor a booking URL, or the only booking
-   *         channel was a malformed URL. Consumers may therefore treat a non-null return as
-   *         "this leg has at least one booking method."
+   *         or it carries neither a phone number nor a booking URL. Consumers may therefore
+   *         treat a non-null return as "this leg has at least one booking method."
    */
   @Nullable
   static BookingInfo toBookingInfo(
@@ -349,19 +332,15 @@ public class CarpoolItineraryMapper {
     if (contact.getPhoneNumber() != null) {
       bookingMethods.add(BookingMethod.CALL_OFFICE);
     }
-    String effectiveUrl =
-      contact.getBookingUrl() == null
-        ? null
-        : expandPassengerCoordinates(contact.getBookingUrl(), pickup, dropoff);
-    if (effectiveUrl != null) {
+    String bookingUrl = contact.getBookingUrl();
+    String expandedUrl =
+      bookingUrl == null ? null : BookingUrlTemplate.expand(bookingUrl, pickup, dropoff);
+    if (expandedUrl != null) {
       bookingMethods.add(BookingMethod.ONLINE);
     }
-    if (bookingMethods.isEmpty()) {
-      return null;
-    }
-    ContactInfo effectiveContact = Objects.equals(effectiveUrl, contact.getBookingUrl())
+    ContactInfo effectiveContact = Objects.equals(expandedUrl, bookingUrl)
       ? contact
-      : contact.copy().withBookingUrl(effectiveUrl).build();
+      : contact.copy().withBookingUrl(expandedUrl).build();
 
     return BookingInfo.of()
       .withContactInfo(effectiveContact)
@@ -380,52 +359,6 @@ public class CarpoolItineraryMapper {
     List<GraphPath<State, Edge, Vertex>> sharedSegments
   ) {
     return sharedSegments.getLast().states.getLast().getVertex().toWgsCoordinate();
-  }
-
-  /**
-   * Expands the {@code {from}} and {@code {to}} placeholders in a booking URL template with the
-   * passenger's carpool boarding and alighting coordinates, each as {@code "latitude,longitude"}
-   * with six decimals.
-   * <p>
-   * The template is the provider's URL verbatim: the provider, not OTP, decides where in the URL
-   * the coordinates land and what surrounds them. Every occurrence is expanded, in query, path or
-   * fragment alike. A template with neither placeholder is returned unchanged — that is how a
-   * provider declines the coordinates.
-   * <p>
-   * Curly braces are not legal URI characters, so expansion runs on the raw string and only the
-   * result is parsed. Coordinates are not percent-encoded: digits, {@code .}, {@code -} and
-   * {@code ,} are all legal unencoded in a URI.
-   *
-   * @return the expanded URL, or {@code null} if the result is not a parseable URI — the failure
-   *         is logged and the caller drops the URL along with {@link BookingMethod#ONLINE}. An
-   *         unrecognised placeholder such as {@code {From}} lands here too: its braces survive
-   *         expansion and leave the result invalid.
-   */
-  @Nullable
-  private static String expandPassengerCoordinates(
-    String urlTemplate,
-    WgsCoordinate pickup,
-    WgsCoordinate dropoff
-  ) {
-    String url = urlTemplate
-      .replace("{from}", formatCoordinate(pickup))
-      .replace("{to}", formatCoordinate(dropoff));
-    try {
-      // Parsed only to reject invalid URIs. URI#toString returns the string it was built from,
-      // so the provider's URL stays byte-for-byte intact.
-      return new URI(url).toString();
-    } catch (URISyntaxException e) {
-      LOG.info(
-        "Carpool booking URL '{}' is not a valid URI; dropping URL from booking info: {}",
-        urlTemplate,
-        e.getMessage()
-      );
-      return null;
-    }
-  }
-
-  private static String formatCoordinate(WgsCoordinate coordinate) {
-    return String.format(Locale.ROOT, "%.6f,%.6f", coordinate.latitude(), coordinate.longitude());
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/internal/CarpoolItineraryMapper.java
@@ -296,18 +296,20 @@ public class CarpoolItineraryMapper {
   /**
    * Builds the carpool leg's {@code pickupBookingInfo} from the trip's public-contact details.
    * <p>
-   * The contact's {@code bookingUrl} (if present) is augmented with {@code from_coordinate} and
-   * {@code to_coordinate} query parameters reflecting the passenger's carpool boarding and
-   * alighting vertices — i.e. where the passenger gets in/out of the driver's car. These are
-   * distinct from the passenger's walking endpoints (handled by the surrounding walk legs) and
-   * from the driver's trip origin/destination.
+   * The contact's {@code bookingUrl} (if present) is treated as a URI template: its
+   * {@code {from}} and {@code {to}} placeholders are expanded with the passenger's carpool
+   * boarding and alighting vertices — i.e. where the passenger gets in/out of the driver's car.
+   * These are distinct from the passenger's walking endpoints (handled by the surrounding walk
+   * legs) and from the driver's trip origin/destination. See
+   * {@link #expandPassengerCoordinates(String, WgsCoordinate, WgsCoordinate)} for the template
+   * syntax and for the treatment of a URL that carries no placeholders.
    * <p>
-   * If the contact's booking URL cannot be parsed as a valid {@link URI}, the URL is dropped from
-   * the returned {@code BookingInfo} (a malformed URL is logged and treated as if the trip
-   * published no booking URL at all) and {@link BookingMethod#ONLINE} is omitted from
-   * the booking methods. This keeps the "non-null return ⇒ at least one usable booking method"
-   * contract honest: a {@code BookingInfo} is never returned advertising {@code ONLINE} without
-   * a URL the user can actually open.
+   * If the booking URL is not a valid {@link URI} once its placeholders have been expanded, the
+   * URL is dropped from the returned {@code BookingInfo} (the failure is logged and the trip is
+   * treated as if it published no booking URL at all) and {@link BookingMethod#ONLINE} is omitted
+   * from the booking methods. This keeps the "non-null return ⇒ at least one usable booking
+   * method" contract honest: a {@code BookingInfo} is never returned advertising {@code ONLINE}
+   * without a URL the user can actually open.
    * <p>
    * {@code latestBookingTime} is a temporary placeholder: how a real booking deadline should be
    * sourced for carpool trips is yet to be decided, so it is approximated by the trip's
@@ -322,10 +324,10 @@ public class CarpoolItineraryMapper {
    * @param contact the trip's public-contact details, or {@code null} if the trip publishes none.
    * @param tripStartTime the driver's trip start time; only the time-of-day is used, as the
    *        placeholder source for {@code latestBookingTime}.
-   * @param pickup the carpool boarding coordinate (where the passenger gets into the car), used to
-   *        augment the booking URL with {@code from_coordinate}.
+   * @param pickup the carpool boarding coordinate (where the passenger gets into the car),
+   *        expanded into the booking URL's {@code {from}} placeholder.
    * @param dropoff the carpool alighting coordinate (where the passenger gets out of the car),
-   *        used to augment the booking URL with {@code to_coordinate}.
+   *        expanded into the booking URL's {@code {to}} placeholder.
    * @return a booking info populated with the contact details and derived booking methods
    *         (CALL_OFFICE if phone is set, ONLINE if URL is set and parses), or {@code null} when
    *         no actionable booking method can be derived — i.e. {@code contact} is {@code null},
@@ -350,7 +352,7 @@ public class CarpoolItineraryMapper {
     String effectiveUrl =
       contact.getBookingUrl() == null
         ? null
-        : appendPassengerCoordinates(contact.getBookingUrl(), pickup, dropoff);
+        : expandPassengerCoordinates(contact.getBookingUrl(), pickup, dropoff);
     if (effectiveUrl != null) {
       bookingMethods.add(BookingMethod.ONLINE);
     }
@@ -381,50 +383,49 @@ public class CarpoolItineraryMapper {
   }
 
   /**
-   * Appends {@code from_coordinate} and {@code to_coordinate} query parameters to the booking URL
-   * so the carpool provider's booking page can pre-fill the passenger's pickup and dropoff.
+   * Expands the {@code {from}} and {@code {to}} placeholders in a booking URL template with the
+   * passenger's carpool boarding and alighting coordinates, each as {@code "latitude,longitude"}
+   * with six decimals.
    * <p>
-   * The URL is parsed via {@link URI} so that any existing query string is merged with {@code &}
-   * (rather than a second {@code ?}) and any fragment ends up after the appended parameters
-   * rather than swallowing them.
+   * The template is the provider's URL verbatim: the provider, not OTP, decides where in the URL
+   * the coordinates land and what surrounds them. Every occurrence is expanded, in query, path or
+   * fragment alike. A template with neither placeholder is returned unchanged — that is how a
+   * provider declines the coordinates.
+   * <p>
+   * Curly braces are not legal URI characters, so expansion runs on the raw string and only the
+   * result is parsed. Coordinates are not percent-encoded: digits, {@code .}, {@code -} and
+   * {@code ,} are all legal unencoded in a URI.
    *
-   * @return the augmented URL, or {@code null} if the input is not a parseable URI — in which
-   *         case the failure is logged and the caller should drop the URL (and the
-   *         {@link BookingMethod#ONLINE} booking method along with it).
+   * @return the expanded URL, or {@code null} if the result is not a parseable URI — the failure
+   *         is logged and the caller drops the URL along with {@link BookingMethod#ONLINE}. An
+   *         unrecognised placeholder such as {@code {From}} lands here too: its braces survive
+   *         expansion and leave the result invalid.
    */
   @Nullable
-  private static String appendPassengerCoordinates(
-    String url,
+  private static String expandPassengerCoordinates(
+    String urlTemplate,
     WgsCoordinate pickup,
     WgsCoordinate dropoff
   ) {
-    String addedQuery = String.format(
-      Locale.ROOT,
-      "from_coordinate=%.6f,%.6f&to_coordinate=%.6f,%.6f",
-      pickup.latitude(),
-      pickup.longitude(),
-      dropoff.latitude(),
-      dropoff.longitude()
-    );
+    String url = urlTemplate
+      .replace("{from}", formatCoordinate(pickup))
+      .replace("{to}", formatCoordinate(dropoff));
     try {
-      URI uri = new URI(url);
-      String existingQuery = uri.getQuery();
-      String mergedQuery = existingQuery == null ? addedQuery : existingQuery + "&" + addedQuery;
-      return new URI(
-        uri.getScheme(),
-        uri.getAuthority(),
-        uri.getPath(),
-        mergedQuery,
-        uri.getFragment()
-      ).toString();
+      // Parsed only to reject invalid URIs. URI#toString returns the string it was built from,
+      // so the provider's URL stays byte-for-byte intact.
+      return new URI(url).toString();
     } catch (URISyntaxException e) {
       LOG.info(
-        "Failed to parse carpool booking URL '{}'; dropping URL from booking info: {}",
-        url,
+        "Carpool booking URL '{}' is not a valid URI; dropping URL from booking info: {}",
+        urlTemplate,
         e.getMessage()
       );
       return null;
     }
+  }
+
+  private static String formatCoordinate(WgsCoordinate coordinate) {
+    return String.format(Locale.ROOT, "%.6f,%.6f", coordinate.latitude(), coordinate.longitude());
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/updater/CarpoolSiriMapper.java
@@ -20,6 +20,7 @@ import org.opentripplanner.ext.carpooling.model.CarpoolStop;
 import org.opentripplanner.ext.carpooling.model.CarpoolTrip;
 import org.opentripplanner.ext.carpooling.model.CarpoolTripBuilder;
 import org.opentripplanner.ext.carpooling.util.BeelineEstimator;
+import org.opentripplanner.ext.carpooling.util.BookingUrlTemplate;
 import org.opentripplanner.street.geometry.WgsCoordinate;
 import org.opentripplanner.street.model.StreetConstants;
 import org.opentripplanner.transit.model.organization.ContactInfo;
@@ -29,6 +30,7 @@ import uk.org.siri.siri21.AimedFlexibleArea;
 import uk.org.siri.siri21.CircularAreaStructure;
 import uk.org.siri.siri21.EstimatedCall;
 import uk.org.siri.siri21.EstimatedVehicleJourney;
+import uk.org.siri.siri21.SimpleContactStructure;
 
 /**
  * Maps SIRI EstimatedVehicleJourney messages to {@link CarpoolTrip} instances.
@@ -190,15 +192,45 @@ public class CarpoolSiriMapper {
 
     var publicContact = journey.getPublicContact();
     if (publicContact != null) {
-      builder.withPublicContactInformation(
-        ContactInfo.of()
-          .withPhoneNumber(publicContact.getPhoneNumber())
-          .withBookingUrl(publicContact.getUrl())
-          .build()
-      );
+      var contactInformation = mapPublicContact(publicContact, tripId);
+      if (contactInformation != null) {
+        builder.withPublicContactInformation(contactInformation);
+      }
     }
 
     return builder.build();
+  }
+
+  /**
+   * Maps the journey's public contact, dropping a booking URL the passenger could not open.
+   *
+   * @return the contact information, or {@code null} if neither channel survives.
+   */
+  @Nullable
+  private static ContactInfo mapPublicContact(SimpleContactStructure publicContact, String tripId) {
+    var phoneNumber = publicContact.getPhoneNumber();
+    var bookingUrl = usableBookingUrl(publicContact.getUrl(), tripId);
+
+    if (phoneNumber == null && bookingUrl == null) {
+      return null;
+    }
+    return ContactInfo.of().withPhoneNumber(phoneNumber).withBookingUrl(bookingUrl).build();
+  }
+
+  /**
+   * Returns the booking URL template, or {@code null} when it would expand to a URL the passenger
+   * cannot open.
+   */
+  @Nullable
+  private static String usableBookingUrl(@Nullable String bookingUrl, String tripId) {
+    if (bookingUrl == null) {
+      return null;
+    }
+    if (!BookingUrlTemplate.isUsable(bookingUrl)) {
+      LOG.info("Trip {}: dropping unusable public contact booking URL '{}'.", tripId, bookingUrl);
+      return null;
+    }
+    return bookingUrl;
   }
 
   /**

--- a/application/src/ext/java/org/opentripplanner/ext/carpooling/util/BookingUrlTemplate.java
+++ b/application/src/ext/java/org/opentripplanner/ext/carpooling/util/BookingUrlTemplate.java
@@ -1,0 +1,46 @@
+package org.opentripplanner.ext.carpooling.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import org.opentripplanner.street.geometry.WgsCoordinate;
+
+/**
+ * The booking URL a carpool provider publishes, holding {@code {from}} and {@code {to}}
+ * placeholders for the passenger's carpool boarding and alighting points. Each is expanded to
+ * {@code "latitude,longitude"} at six decimals, wherever in the URL it appears. Both are
+ * optional: a URL holding neither is returned unchanged.
+ */
+public final class BookingUrlTemplate {
+
+  private static final String FROM_PLACEHOLDER = "{from}";
+  private static final String TO_PLACEHOLDER = "{to}";
+
+  /** Stand-in for validating a template before a passenger's coordinates are known. */
+  private static final WgsCoordinate PROBE = new WgsCoordinate(-90, -180);
+
+  private BookingUrlTemplate() {}
+
+  /**
+   * Checks that the template expands to a parseable URI. Curly braces are not legal URI
+   * characters, so it is the expansion that is parsed, not the template as published.
+   */
+  public static boolean isUsable(String urlTemplate) {
+    try {
+      new URI(expand(urlTemplate, PROBE, PROBE));
+      return true;
+    } catch (URISyntaxException e) {
+      return false;
+    }
+  }
+
+  public static String expand(String urlTemplate, WgsCoordinate from, WgsCoordinate to) {
+    return urlTemplate
+      .replace(FROM_PLACEHOLDER, formatCoordinate(from))
+      .replace(TO_PLACEHOLDER, formatCoordinate(to));
+  }
+
+  private static String formatCoordinate(WgsCoordinate coordinate) {
+    return String.format(Locale.ROOT, "%.6f,%.6f", coordinate.latitude(), coordinate.longitude());
+  }
+}

--- a/doc/user/sandbox/Carpooling.md
+++ b/doc/user/sandbox/Carpooling.md
@@ -102,9 +102,13 @@ Notes:
 - **Both placeholders are optional.** A URL containing neither is passed through unchanged, so a
   provider that does not want the passenger's coordinates simply publishes a plain URL.
 - **Names are case-sensitive.** `{From}` is not recognised, and since curly braces are not legal
-  URI characters, its leftover braces make the expanded URL unparseable — OTP then logs the
-  problem, drops the URL, and omits the `ONLINE` booking method rather than returning a link that
-  cannot be opened. The same applies to any booking URL that is not a valid URI once expanded.
+  URI characters, its leftover braces would make the expanded URL unparseable.
+
+#### Contact validation
+
+The booking URL of an incoming SIRI message is checked when the message is read: it must expand to
+a parseable URI. A URL that fails is logged and left off the trip; the trip itself is kept either
+way, and the booking information on the carpool leg advertises only the channels that survived.
 
 ## Features
 

--- a/doc/user/sandbox/Carpooling.md
+++ b/doc/user/sandbox/Carpooling.md
@@ -67,6 +67,45 @@ carpool trips. The system maps SIRI-ET data as follows:
 
 The system supports multi-stop trips where drivers have already accepted multiple passengers.
 
+#### Booking URL templates
+
+A trip's `PublicContact/Url` is treated as a URL template. OTP expands two placeholders in it
+before returning the URL on the carpool leg's booking information:
+
+| Placeholder | Expanded with                                                        |
+| ----------- | -------------------------------------------------------------------- |
+| `{from}`    | The carpool **boarding** point — where the passenger gets in the car |
+| `{to}`      | The carpool **alighting** point — where the passenger gets out       |
+
+Each is replaced by `latitude,longitude` at six decimals, for example
+`59.911491,10.750184`. These are the points on the driver's route, which are generally *not* the
+passenger's requested origin and destination (the passenger walks to and from them) and not the
+driver's own origin and destination.
+
+So a provider publishing
+
+```
+https://example.com/book/ENT:ServiceJourney:1?pickup={from}&dropoff={to}
+```
+
+receives
+
+```
+https://example.com/book/ENT:ServiceJourney:1?pickup=59.911491,10.750184&dropoff=59.933077,10.784618
+```
+
+Notes:
+
+- **The provider owns the URL.** OTP does not choose the parameter names, their order, or where in
+  the URL the coordinates land. Placeholders are expanded wherever they appear — query string,
+  path segment or fragment — and every occurrence is expanded.
+- **Both placeholders are optional.** A URL containing neither is passed through unchanged, so a
+  provider that does not want the passenger's coordinates simply publishes a plain URL.
+- **Names are case-sensitive.** `{From}` is not recognised, and since curly braces are not legal
+  URI characters, its leftover braces make the expanded URL unparseable — OTP then logs the
+  problem, drops the URL, and omits the `ONLINE` booking method rather than returning a link that
+  cannot be opened. The same applies to any booking URL that is not a valid URI once expanded.
+
 ## Features
 
 ### Trip Matching


### PR DESCRIPTION
### Summary

The carpool leg's booking URL had `from_coordinate`/`to_coordinate` appended unconditionally,
forcing OTP's parameter names and placement on every provider. The trip's `PublicContact/Url` is
now a URL template: OTP expands `{from}` and `{to}` — the passenger's carpool boarding and
alighting points as `latitude,longitude` at six decimals — wherever the provider puts them, and
passes a URL with neither placeholder through unchanged.

### Unit tests

- Were unit tests added/updated?

Yes

- Was any manual verification done?

Yes

- Any observations on changes to performance?

No

- Was the code designed so it is unit testable?

Yes

- Were any tests applied to the smallest appropriate unit?

Yes

- Do all tests
  pass [the continuous integration service](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/user/Developers-Guide.md#continuous-integration)
  ?

Yes

### Documentation

`doc/user/sandbox/Carpooling.md` documents the template syntax, the coordinate format, and the
  handling of absent and misspelled placeholders

