### PR TITLE
Add snowAndIce to the Transmodel TransportMode enum

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
+++ b/application/src/main/java/org/opentripplanner/apis/transmodel/model/EnumTypes.java
@@ -491,6 +491,7 @@ public class EnumTypes {
     .value("funicular", TransitMode.FUNICULAR)
     .value("lift", TransitMode.GONDOLA)
     .value("rail", TransitMode.RAIL)
+    .value("snowAndIce", TransitMode.SNOW_AND_ICE)
     .value("metro", TransitMode.SUBWAY)
     .value("taxi", TransitMode.TAXI)
     .value("tram", TransitMode.TRAM)

--- a/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
+++ b/application/src/main/resources/org/opentripplanner/apis/transmodel/schema.graphql
@@ -2077,6 +2077,7 @@ enum TransportMode {
   metro
   monorail
   rail
+  snowAndIce
   taxi
   tram
   trolleybus

--- a/application/src/test/java/org/opentripplanner/apis/transmodel/model/EnumTypesTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/transmodel/model/EnumTypesTest.java
@@ -122,6 +122,12 @@ class EnumTypesTest {
     assertEquals(TransitMode.CARPOOL, mappedValue(LEG_MODE, "carpool"));
   }
 
+  @Test
+  void assertSnowAndIceIsMappedInBothModeEnums() {
+    assertEquals(TransitMode.SNOW_AND_ICE, mappedValue(TRANSPORT_MODE, "snowAndIce"));
+    assertEquals(TransitMode.SNOW_AND_ICE, mappedValue(LEG_MODE, "snowAndIce"));
+  }
+
   private static Object mappedValue(GraphQLEnumType type, String apiName) {
     var value = type.getValue(apiName);
     assertNotNull(value, () -> "'%s' is not mapped in enum %s".formatted(apiName, type.getName()));


### PR DESCRIPTION
### Summary

Add the missing `snowAndIce` value to the Transmodel `TransportMode` enum.
See #7951 and #7114

### Unit tests
Added test


