### PR TITLE
Allow nanosecond precision in NeTEx date times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <logback.version>1.6.3</logback.version>
         <lucene.version>10.5.0</lucene.version>
         <micrometer.version>1.17.1</micrometer.version>
-        <netex-java-model.version>2.0.15.3</netex-java-model.version>
+        <netex-java-model.version>2.0.15.4</netex-java-model.version>
         <netcdf4.version>5.6.0</netcdf4.version>
         <protobuf.version>4.35.1</protobuf.version>
         <siri-java-model.version>2.0.6</siri-java-model.version>


### PR DESCRIPTION
### Summary

In #7956 we noticed that NeTEx date times with sub-millisecond precision would silently be converted to null, which would fail the parsing of an Italian NeTEx feed with data like this:

```   
<UicOperatingPeriod
	xmlns="http://www.netex.org.uk/netex"
	xmlns:ns2="http://www.opengis.net/gml/3.2"
	xmlns:ns3="http://www.siri.org.uk/siri" version="153" id="IT:ITH4:UicOperatingPeriod:U182_20260416_0">
	<FromDate>2026-05-03T23:30:09.398629+02:00</FromDate>
	<ToDate>2026-08-31T00:00:00</ToDate>
	<ValidDayBits>111111011111101111110111111010111101111100111110011111001111100111110011111001111100111110011111001111100111110011111001</ValidDayBits>
</UicOperatingPeriod>
```

https://github.com/entur/netex-java-model/pull/298 in the upstream library fixes the issue.

BTW, I'm not saying that this is good data - it is very ambiguous, but that is a separate issue.

### Issue

https://github.com/noi-techpark/opendatahub-mentor-otp/issues/330