### PR TITLE
Deprecate serviceId in GTFS API and stop populating it

### DIFF
--- a/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
+++ b/application/src/main/java/org/opentripplanner/apis/gtfs/datafetchers/TripImpl.java
@@ -329,7 +329,9 @@ public class TripImpl implements GraphQLDataFetchers.GraphQLTrip {
 
   @Override
   public DataFetcher<String> serviceId() {
-    return environment -> getSource(environment).getServiceId().toString();
+    // Deprecated: GTFS service-id is being phased out as an internal OTP concept, see
+    // https://github.com/opentripplanner/OpenTripPlanner/issues/7972
+    return environment -> null;
   }
 
   @Override

--- a/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
+++ b/application/src/main/resources/org/opentripplanner/apis/gtfs/schema.graphqls
@@ -3000,7 +3000,7 @@ type Trip implements Node {
   routeShortName: String
   "Hash code of the trip. This value is stable and not dependent on the trip id."
   semanticHash: String!
-  serviceId: String
+  serviceId: String @deprecated(reason : "This field always returns null. GTFS's service-id is being phased out as an internal OTP concept, see [GitHub issue](https://github.com/opentripplanner/OpenTripPlanner/issues/7972).\nThis field is subject for removal in September 2028. If you want this field to stay, please notify the OTP community.")
   shapeId: String
   "List of stops this trip passes through"
   stops: [Stop!]!


### PR DESCRIPTION
### Summary

Deprecates `Trip.serviceId` in the GTFS GraphQL API and stops populating it — the resolver now
always returns `null`. First step towards removing GTFS service-id as an internal OTP domain
concept (#7972).

### Issue

Related to #7972.

No usage of this field was found after contacting known consumers of the GTFS API. Per the
[API deprecation policy](https://github.com/opentripplanner/OpenTripPlanner/blob/dev-2.x/doc/dev/decisionrecords/APIGraphQLDesign.md),
deprecated fields can be removed after 2 years, so the field is marked as subject for removal in
September 2028.

### Unit tests

🟥 No test changes needed — no existing test or query snapshot references `serviceId`.

### Documentation

✅ The GraphQL schema description on the field states the deprecation reason and removal
timeline.

### Changelog

The PR title doubles as the changelog entry.

### Bumping the serialization version id

🟥 No changes to the serialized graph format — this is a GraphQL API-only change.