### PR TITLE
Transit shape simplification

### DIFF
--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -146,8 +146,15 @@ public class GraphBuilderModules {
       config.getTransitServicePeriod(),
       fareServiceFactory,
       config.maxStopToShapeSnapDistance,
+      transitShapeSimplificationToleranceMetersOrDisabled(config),
       config.getSubwayAccessTimeSeconds()
     );
+  }
+
+  private static double transitShapeSimplificationToleranceMetersOrDisabled(BuildConfig config) {
+    return config.transitShapeSimplificationToleranceMeters == null
+      ? 0.0
+      : config.transitShapeSimplificationToleranceMeters;
   }
 
   @Provides

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/configure/GraphBuilderModules.java
@@ -146,15 +146,9 @@ public class GraphBuilderModules {
       config.getTransitServicePeriod(),
       fareServiceFactory,
       config.maxStopToShapeSnapDistance,
-      transitShapeSimplificationToleranceMetersOrDisabled(config),
+      config.transitShapeSimplificationToleranceMeters(),
       config.getSubwayAccessTimeSeconds()
     );
-  }
-
-  private static double transitShapeSimplificationToleranceMetersOrDisabled(BuildConfig config) {
-    return config.transitShapeSimplificationToleranceMeters == null
-      ? 0.0
-      : config.transitShapeSimplificationToleranceMeters;
   }
 
   @Provides

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessor.java
@@ -26,6 +26,7 @@ import org.opentripplanner.graph_builder.issues.ShapeGeometryTooFar;
 import org.opentripplanner.model.ShapePoint;
 import org.opentripplanner.model.StopTime;
 import org.opentripplanner.model.impl.TransitDataImportBuilder;
+import org.opentripplanner.street.geometry.DouglasPeuckerAlgorithm;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.transit.model.site.StopLocation;
@@ -82,17 +83,21 @@ public class GeometryProcessor {
    */
   public List<LineString> createHopGeometries(Trip trip) {
     List<StopTime> stopTimes = builder.getStopTimesSortedByTrip().get(trip);
-    List<LineString> hopGeometries;
     if (
       trip.getShapeId() == null ||
       trip.getShapeId().getId() == null ||
       trip.getShapeId().getId().isEmpty()
     ) {
-      hopGeometries = Arrays.asList(createStraightLineHopGeometries(stopTimes));
-    } else {
-      hopGeometries = Arrays.asList(createGeometry(trip.getShapeId(), stopTimes));
+      // a straight line between two stops has no interior points to simplify away
+      return Arrays.asList(createStraightLineHopGeometries(stopTimes));
     }
-    return GeometryUtils.simplify(hopGeometries, transitShapeSimplificationToleranceMeters);
+    LineString[] geometry = createGeometry(trip.getShapeId(), stopTimes);
+
+    return transitShapeSimplificationToleranceMeters <= 0
+      ? Arrays.asList(geometry)
+      : Arrays.stream(geometry)
+          .map(l -> DouglasPeuckerAlgorithm.of(l, transitShapeSimplificationToleranceMeters))
+          .toList();
   }
 
   private static boolean equals(LinearLocation startIndex, LinearLocation endIndex) {

--- a/application/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessor.java
+++ b/application/src/main/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessor.java
@@ -53,16 +53,19 @@ public class GeometryProcessor {
   // this is a thread-safe implementation
   private final Map<FeedScopedId, double[]> distancesByShapeId = new ConcurrentHashMap<>();
   private final double maxStopToShapeSnapDistance;
+  private final double transitShapeSimplificationToleranceMeters;
   private final DataImportIssueStore issueStore;
 
   public GeometryProcessor(
     TransitDataImportBuilder builder,
     double maxStopToShapeSnapDistance,
+    double transitShapeSimplificationToleranceMeters,
     DataImportIssueStore issueStore
   ) {
     this.builder = builder;
     this.maxStopToShapeSnapDistance =
       maxStopToShapeSnapDistance > 0 ? maxStopToShapeSnapDistance : 150;
+    this.transitShapeSimplificationToleranceMeters = transitShapeSimplificationToleranceMeters;
     this.issueStore = issueStore;
   }
 
@@ -79,15 +82,17 @@ public class GeometryProcessor {
    */
   public List<LineString> createHopGeometries(Trip trip) {
     List<StopTime> stopTimes = builder.getStopTimesSortedByTrip().get(trip);
+    List<LineString> hopGeometries;
     if (
       trip.getShapeId() == null ||
       trip.getShapeId().getId() == null ||
       trip.getShapeId().getId().isEmpty()
     ) {
-      return Arrays.asList(createStraightLineHopGeometries(stopTimes));
+      hopGeometries = Arrays.asList(createStraightLineHopGeometries(stopTimes));
+    } else {
+      hopGeometries = Arrays.asList(createGeometry(trip.getShapeId(), stopTimes));
     }
-
-    return Arrays.asList(createGeometry(trip.getShapeId(), stopTimes));
+    return GeometryUtils.simplify(hopGeometries, transitShapeSimplificationToleranceMeters);
   }
 
   private static boolean equals(LinearLocation startIndex, LinearLocation endIndex) {

--- a/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
+++ b/application/src/main/java/org/opentripplanner/gtfs/graphbuilder/GtfsModule.java
@@ -53,6 +53,7 @@ public class GtfsModule implements GraphBuilderModule {
   private final DeduplicatorService deduplicator;
 
   private final double maxStopToShapeSnapDistance;
+  private final double transitShapeSimplificationToleranceMeters;
   private final int subwayAccessTime_s;
 
   public GtfsModule(
@@ -65,6 +66,7 @@ public class GtfsModule implements GraphBuilderModule {
     LocalDateRange transitPeriodLimit,
     FareServiceFactory fareServiceFactory,
     double maxStopToShapeSnapDistance,
+    double transitShapeSimplificationToleranceMeters,
     int subwayAccessTime_s
   ) {
     this.gtfsBundles = bundles;
@@ -76,6 +78,7 @@ public class GtfsModule implements GraphBuilderModule {
     this.transitPeriodLimit = transitPeriodLimit;
     this.fareServiceFactory = fareServiceFactory;
     this.maxStopToShapeSnapDistance = maxStopToShapeSnapDistance;
+    this.transitShapeSimplificationToleranceMeters = transitShapeSimplificationToleranceMeters;
     this.subwayAccessTime_s = subwayAccessTime_s;
   }
 
@@ -98,6 +101,7 @@ public class GtfsModule implements GraphBuilderModule {
       transitPeriodLimit,
       new GtfsFareServiceFactory(),
       150.0,
+      0.0,
       120
     );
   }
@@ -151,6 +155,7 @@ public class GtfsModule implements GraphBuilderModule {
         GeometryProcessor geometryProcessor = new GeometryProcessor(
           builder,
           maxStopToShapeSnapDistance,
+          transitShapeSimplificationToleranceMeters,
           issueStore
         );
 

--- a/application/src/main/java/org/opentripplanner/netex/NetexBundle.java
+++ b/application/src/main/java/org/opentripplanner/netex/NetexBundle.java
@@ -48,6 +48,7 @@ public class NetexBundle implements Closeable {
   private final Set<String> ferryIdsNotAllowedForBicycle;
   private final Collection<FeedScopedId> routeToCentroidStopPlaceIds;
   private final double maxStopToShapeSnapDistance;
+  private final double transitShapeSimplificationToleranceMeters;
   private final boolean noTransfersOnIsolatedStops;
   private final Set<IgnorableFeature> ignoredFeatures;
   /** The NeTEx entities loaded from the input files and passed on to the mapper. */
@@ -66,6 +67,7 @@ public class NetexBundle implements Closeable {
     Set<String> ferryIdsNotAllowedForBicycle,
     Collection<FeedScopedId> routeToCentroidStopPlaceIds,
     double maxStopToShapeSnapDistance,
+    double transitShapeSimplificationToleranceMeters,
     boolean noTransfersOnIsolatedStops,
     Set<IgnorableFeature> ignorableFeatures
   ) {
@@ -76,6 +78,7 @@ public class NetexBundle implements Closeable {
     this.ferryIdsNotAllowedForBicycle = ferryIdsNotAllowedForBicycle;
     this.routeToCentroidStopPlaceIds = Set.copyOf(routeToCentroidStopPlaceIds);
     this.maxStopToShapeSnapDistance = maxStopToShapeSnapDistance;
+    this.transitShapeSimplificationToleranceMeters = transitShapeSimplificationToleranceMeters;
     this.noTransfersOnIsolatedStops = noTransfersOnIsolatedStops;
     this.ignoredFeatures = Set.copyOf(ignorableFeatures);
   }
@@ -99,6 +102,7 @@ public class NetexBundle implements Closeable {
       ferryIdsNotAllowedForBicycle,
       routeToCentroidStopPlaceIds,
       maxStopToShapeSnapDistance,
+      transitShapeSimplificationToleranceMeters,
       noTransfersOnIsolatedStops
     );
 

--- a/application/src/main/java/org/opentripplanner/netex/configure/NetexConfigure.java
+++ b/application/src/main/java/org/opentripplanner/netex/configure/NetexConfigure.java
@@ -30,10 +30,10 @@ import org.opentripplanner.transit.service.TransitRepository;
  */
 public class NetexConfigure {
 
-  private final BuildConfig buildParams;
+  private final BuildConfig buildConfig;
 
-  public NetexConfigure(BuildConfig builderParams) {
-    this.buildParams = builderParams;
+  public NetexConfigure(BuildConfig buildConfig) {
+    this.buildConfig = buildConfig;
   }
 
   public NetexModule createNetexModule(
@@ -62,8 +62,8 @@ public class NetexConfigure {
       parkingRepository,
       streetDetailsRepository,
       issueStore,
-      buildParams.getSubwayAccessTimeSeconds(),
-      buildParams.getTransitServicePeriod(),
+      buildConfig.getSubwayAccessTimeSeconds(),
+      buildConfig.getTransitServicePeriod(),
       netexBundles
     );
   }
@@ -82,18 +82,12 @@ public class NetexConfigure {
       hierarchy(source, config),
       transitServiceBuilder,
       config.ferryIdsNotAllowedForBicycle(),
-      buildParams.transitRouteToStationCentroid(),
-      buildParams.maxStopToShapeSnapDistance,
-      transitShapeSimplificationToleranceMetersOrDisabled(),
+      buildConfig.transitRouteToStationCentroid(),
+      buildConfig.maxStopToShapeSnapDistance,
+      buildConfig.transitShapeSimplificationToleranceMeters(),
       config.noTransfersOnIsolatedStops(),
       config.ignoredFeatures()
     );
-  }
-
-  private double transitShapeSimplificationToleranceMetersOrDisabled() {
-    return buildParams.transitShapeSimplificationToleranceMeters == null
-      ? 0.0
-      : buildParams.transitShapeSimplificationToleranceMeters;
   }
 
   private NetexDataSourceHierarchy hierarchy(

--- a/application/src/main/java/org/opentripplanner/netex/configure/NetexConfigure.java
+++ b/application/src/main/java/org/opentripplanner/netex/configure/NetexConfigure.java
@@ -84,9 +84,16 @@ public class NetexConfigure {
       config.ferryIdsNotAllowedForBicycle(),
       buildParams.transitRouteToStationCentroid(),
       buildParams.maxStopToShapeSnapDistance,
+      transitShapeSimplificationToleranceMetersOrDisabled(),
       config.noTransfersOnIsolatedStops(),
       config.ignoredFeatures()
     );
+  }
+
+  private double transitShapeSimplificationToleranceMetersOrDisabled() {
+    return buildParams.transitShapeSimplificationToleranceMeters == null
+      ? 0.0
+      : buildParams.transitShapeSimplificationToleranceMeters;
   }
 
   private NetexDataSourceHierarchy hierarchy(

--- a/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/NetexMapper.java
@@ -68,6 +68,7 @@ public class NetexMapper {
   private final Set<String> ferryIdsNotAllowedForBicycle;
   private final Set<FeedScopedId> routeToCentroidStopPlaceIds;
   private final double maxStopToShapeSnapDistance;
+  private final double transitShapeSimplificationToleranceMeters;
   private final boolean noTransfersOnIsolatedStops;
 
   /** Map entries that cross reference entities within a group/operator, for example Interchanges. */
@@ -96,6 +97,7 @@ public class NetexMapper {
     Set<String> ferryIdsNotAllowedForBicycle,
     Collection<FeedScopedId> routeToCentroidStopPlaceIds,
     double maxStopToShapeSnapDistance,
+    double transitShapeSimplificationToleranceMeters,
     boolean noTransfersOnIsolatedStops
   ) {
     this.transitBuilder = transitBuilder;
@@ -106,6 +108,7 @@ public class NetexMapper {
     this.routeToCentroidStopPlaceIds = Set.copyOf(routeToCentroidStopPlaceIds);
     this.noTransfersOnIsolatedStops = noTransfersOnIsolatedStops;
     this.maxStopToShapeSnapDistance = maxStopToShapeSnapDistance;
+    this.transitShapeSimplificationToleranceMeters = transitShapeSimplificationToleranceMeters;
     this.calendarServiceBuilder = new CalendarServiceBuilder(idFactory);
     this.tripCalendarBuilder = new TripCalendarBuilder(this.calendarServiceBuilder, issueStore);
   }
@@ -463,7 +466,8 @@ public class NetexMapper {
       currentMapperIndexes.getDatedServiceJourneysBySjId(),
       serviceIds,
       deduplicator,
-      maxStopToShapeSnapDistance
+      maxStopToShapeSnapDistance,
+      transitShapeSimplificationToleranceMeters
     );
 
     for (JourneyPattern_VersionStructure journeyPattern : currentNetexIndex

--- a/application/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
@@ -18,6 +18,7 @@ import org.opentripplanner.graph_builder.issues.MissingProjectionInServiceLink;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMap;
 import org.opentripplanner.netex.index.api.ReadOnlyHierarchicalMapById;
 import org.opentripplanner.netex.mapping.support.FeedScopedIdFactory;
+import org.opentripplanner.street.geometry.DouglasPeuckerAlgorithm;
 import org.opentripplanner.street.geometry.GeometryUtils;
 import org.opentripplanner.street.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.transit.model.framework.ImmutableEntityById;
@@ -74,8 +75,11 @@ class ServiceLinkMapper {
         geometries[i] = createSimpleGeometry(stopPattern.getStop(i), stopPattern.getStop(i + 1));
       }
     }
-    List<LineString> hopGeometries = Arrays.asList(geometries);
-    return GeometryUtils.simplify(hopGeometries, transitShapeSimplificationToleranceMeters);
+    return transitShapeSimplificationToleranceMeters <= 0
+      ? Arrays.asList(geometries)
+      : Arrays.stream(geometries)
+          .map(l -> DouglasPeuckerAlgorithm.of(l, transitShapeSimplificationToleranceMeters))
+          .toList();
   }
 
   private LineString[] generateGeometriesFromServiceLinks(

--- a/application/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/ServiceLinkMapper.java
@@ -42,6 +42,7 @@ class ServiceLinkMapper {
   private final ImmutableEntityById<RegularStop> stopById;
   private final DataImportIssueStore issueStore;
   private final double maxStopToShapeSnapDistance;
+  private final double transitShapeSimplificationToleranceMeters;
 
   ServiceLinkMapper(
     FeedScopedIdFactory idFactory,
@@ -49,7 +50,8 @@ class ServiceLinkMapper {
     ReadOnlyHierarchicalMap<String, String> quayIdByStopPointRef,
     ImmutableEntityById<RegularStop> stopById,
     DataImportIssueStore issueStore,
-    double maxStopToShapeSnapDistance
+    double maxStopToShapeSnapDistance,
+    double transitShapeSimplificationToleranceMeters
   ) {
     this.idFactory = idFactory;
     this.serviceLinkById = serviceLinkById;
@@ -57,6 +59,7 @@ class ServiceLinkMapper {
     this.stopById = stopById;
     this.issueStore = issueStore;
     this.maxStopToShapeSnapDistance = maxStopToShapeSnapDistance;
+    this.transitShapeSimplificationToleranceMeters = transitShapeSimplificationToleranceMeters;
   }
 
   List<LineString> getGeometriesByJourneyPattern(
@@ -71,7 +74,8 @@ class ServiceLinkMapper {
         geometries[i] = createSimpleGeometry(stopPattern.getStop(i), stopPattern.getStop(i + 1));
       }
     }
-    return Arrays.asList(geometries);
+    List<LineString> hopGeometries = Arrays.asList(geometries);
+    return GeometryUtils.simplify(hopGeometries, transitShapeSimplificationToleranceMeters);
   }
 
   private LineString[] generateGeometriesFromServiceLinks(

--- a/application/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
+++ b/application/src/main/java/org/opentripplanner/netex/mapping/TripPatternMapper.java
@@ -107,7 +107,8 @@ class TripPatternMapper {
     Multimap<String, DatedServiceJourney> datedServiceJourneysBySJId,
     Map<String, FeedScopedId> serviceIds,
     DeduplicatorService deduplicator,
-    double maxStopToShapeSnapDistance
+    double maxStopToShapeSnapDistance,
+    double transitShapeSimplificationToleranceMeters
   ) {
     this.issueStore = issueStore;
     this.idFactory = idFactory;
@@ -142,7 +143,8 @@ class TripPatternMapper {
       quayIdByStopPointRef,
       stopById,
       issueStore,
-      maxStopToShapeSnapDistance
+      maxStopToShapeSnapDistance,
+      transitShapeSimplificationToleranceMeters
     );
     this.deduplicator = deduplicator;
 

--- a/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -5,6 +5,7 @@ import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V1
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_0;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_1;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_10;
+import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_11;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_2;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_5;
 import static org.opentripplanner.standalone.config.framework.json.OtpVersion.V2_7;
@@ -171,6 +172,14 @@ public class BuildConfig implements OtpDataStoreConfig {
 
   public final DataOverlayConfig dataOverlay;
   public final double maxStopToShapeSnapDistance;
+
+  /**
+   * Douglas-Peucker simplification tolerance for transit route shapes, in meters. {@code null}
+   * (not set) disables simplification.
+   */
+  @Nullable
+  public final Double transitShapeSimplificationToleranceMeters;
+
   public final Set<String> boardingLocationTags;
   public final List<CompoundRefTagGroup> elevatorRefTags;
   private final GraphBuildCacheConfig cache;
@@ -304,6 +313,24 @@ public class BuildConfig implements OtpDataStoreConfig {
         """
       )
       .asDouble(150);
+    this.transitShapeSimplificationToleranceMeters = root
+      .of("transitShapeSimplificationToleranceMeters")
+      .since(V2_11)
+      .summary("Douglas-Peucker simplification tolerance for transit route shapes, in meters.")
+      .description(
+        """
+        Simplifies each trip pattern's shape geometry once, at graph-build time, using the
+        Douglas-Peucker algorithm with this distance tolerance. A larger tolerance removes more
+        points (and any shape detail smaller than it); points are never removed from an
+        individual hop's endpoints, so stop locations are unaffected.
+
+        This is opt-in - leave it unset to keep the raw, unsimplified shapes. A conservative
+        starting point, if enabled, is a few meters: enough to remove excess shape-recording
+        detail on long shapes without visibly straightening real curves.
+        """
+      )
+      .asDoubleOptional()
+      .orElse(null);
     this.multiThreadElevationCalculations = root
       .of("multiThreadElevationCalculations")
       .since(V2_0)

--- a/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/BuildConfig.java
@@ -174,11 +174,10 @@ public class BuildConfig implements OtpDataStoreConfig {
   public final double maxStopToShapeSnapDistance;
 
   /**
-   * Douglas-Peucker simplification tolerance for transit route shapes, in meters. {@code null}
-   * (not set) disables simplification.
+   * Douglas-Peucker simplification tolerance for transit route shapes, in meters. {@code 0}
+   * (the default when not set) disables simplification.
    */
-  @Nullable
-  public final Double transitShapeSimplificationToleranceMeters;
+  private final double transitShapeSimplificationToleranceMeters;
 
   public final Set<String> boardingLocationTags;
   public final List<CompoundRefTagGroup> elevatorRefTags;
@@ -319,18 +318,16 @@ public class BuildConfig implements OtpDataStoreConfig {
       .summary("Douglas-Peucker simplification tolerance for transit route shapes, in meters.")
       .description(
         """
-        Simplifies each trip pattern's shape geometry once, at graph-build time, using the
-        Douglas-Peucker algorithm with this distance tolerance. A larger tolerance removes more
-        points (and any shape detail smaller than it); points are never removed from an
-        individual hop's endpoints, so stop locations are unaffected.
+        Simplifies each trip pattern's shape geometry once, at graph-build time, using the Douglas-Peucker
+        algorithm with this distance tolerance. A larger tolerance removes more points (and any shape detail
+        smaller than it); points are never removed from an individual hop's endpoints, so stop locations are
+        unaffected.
 
-        This is opt-in - leave it unset to keep the raw, unsimplified shapes. A conservative
-        starting point, if enabled, is a few meters: enough to remove excess shape-recording
-        detail on long shapes without visibly straightening real curves.
+        This is opt-in - leave it unset to keep the raw, unsimplified shapes. 0.5 or 3.0 meters may save a
+        significant amount of memory - if some of the feeds contains shapes with a lot of detail.
         """
       )
-      .asDoubleOptional()
-      .orElse(null);
+      .asDouble(0.0);
     this.multiThreadElevationCalculations = root
       .of("multiThreadElevationCalculations")
       .since(V2_0)
@@ -808,5 +805,15 @@ public class BuildConfig implements OtpDataStoreConfig {
    */
   public boolean hasUnknownParameters() {
     return root.hasUnknownParameters();
+  }
+
+  public double transitShapeSimplificationToleranceMeters() {
+    if (transitShapeSimplificationToleranceMeters < 0.0) {
+      LOG.warn(
+        "Build config transitShapeSimplificationToleranceMeters should be greater than 0.0 or not set."
+      );
+      return 0.0;
+    }
+    return transitShapeSimplificationToleranceMeters;
   }
 }

--- a/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
+++ b/application/src/main/java/org/opentripplanner/standalone/config/framework/json/OtpVersion.java
@@ -16,7 +16,8 @@ public enum OtpVersion {
   V2_7("2.7"),
   V2_8("2.8"),
   V2_9("2.9"),
-  V2_10("2.10");
+  V2_10("2.10"),
+  V2_11("2.11");
 
   private final String text;
 

--- a/application/src/test-fixtures/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTestFactory.java
+++ b/application/src/test-fixtures/java/org/opentripplanner/gtfs/graphbuilder/GtfsModuleTestFactory.java
@@ -27,6 +27,7 @@ public class GtfsModuleTestFactory {
       transitPeriodLimit,
       new GtfsFareServiceFactory(),
       150.0,
+      0.0,
       120
     );
   }

--- a/application/src/test/java/org/opentripplanner/ConstantsForTests.java
+++ b/application/src/test/java/org/opentripplanner/ConstantsForTests.java
@@ -335,6 +335,7 @@ public class ConstantsForTests {
       LocalDateRange.ofUnbounded(),
       fareServiceFactory,
       150.0,
+      0.0,
       DurationUtils.durationInSeconds("2m")
     );
 

--- a/application/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessorTest.java
+++ b/application/src/test/java/org/opentripplanner/graph_builder/module/geometry/GeometryProcessorTest.java
@@ -280,7 +280,7 @@ class GeometryProcessorTest {
 
     builder.getShapePoints().put(SHAPE_ID, shapePoints);
 
-    var processor = new GeometryProcessor(builder, 150, NOOP);
+    var processor = new GeometryProcessor(builder, 150, 0.0, NOOP);
     var linestrings = processor.createHopGeometries(trip);
 
     assertLineStringWithinTolerance(expected, linestrings);
@@ -313,7 +313,7 @@ class GeometryProcessorTest {
         )
       );
 
-    var processor = new GeometryProcessor(builder, 150, NOOP);
+    var processor = new GeometryProcessor(builder, 150, 0.0, NOOP);
     var linestrings = processor.createHopGeometries(trip);
     var expected = List.of(
       // the bus has to call at the return because of the shape distance traveled
@@ -336,7 +336,7 @@ class GeometryProcessorTest {
       .toList();
     builder.getStopTimesSortedByTrip().put(trip, stopTimes);
 
-    var processor = new GeometryProcessor(builder, 150, NOOP);
+    var processor = new GeometryProcessor(builder, 150, 0.0, NOOP);
     var linestrings = processor.createHopGeometries(trip);
 
     assertLineStringWithinTolerance(
@@ -359,7 +359,7 @@ class GeometryProcessorTest {
     var stopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, trip, "8:00");
     builder.getStopTimesSortedByTrip().put(trip, stopTimes);
 
-    var processor = new GeometryProcessor(builder, 150, issueStore);
+    var processor = new GeometryProcessor(builder, 150, 0.0, issueStore);
     var linestrings = processor.createHopGeometries(trip);
 
     assertThat(linestrings).hasSize(2);

--- a/application/src/test/java/org/opentripplanner/gtfs/GenerateTripPatternsOperationTest.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/GenerateTripPatternsOperationTest.java
@@ -126,6 +126,7 @@ class GenerateTripPatternsOperationTest {
     geometryProcessor = new GeometryProcessor(
       transitServiceBuilder,
       maxStopToShapeSnapDistance,
+      0.0,
       issueStore
     );
   }

--- a/application/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
+++ b/application/src/test/java/org/opentripplanner/gtfs/GtfsContextBuilder.java
@@ -127,7 +127,7 @@ public class GtfsContextBuilder {
       issueStore,
       deduplicator(),
       calendarService().getServiceIds(),
-      new GeometryProcessor(transitBuilder, 150, issueStore)
+      new GeometryProcessor(transitBuilder, 150, 0.0, issueStore)
     ).run();
   }
 

--- a/application/src/test/java/org/opentripplanner/netex/mapping/NetexMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/NetexMapperTest.java
@@ -61,6 +61,7 @@ class NetexMapperTest {
       Set.of(),
       Set.of(),
       10,
+      0.0,
       false
     );
 
@@ -87,6 +88,7 @@ class NetexMapperTest {
       Set.of(),
       Set.of(),
       10,
+      0.0,
       false
     );
 
@@ -120,6 +122,7 @@ class NetexMapperTest {
       Set.of(),
       Set.of(),
       10,
+      0.0,
       false
     );
 

--- a/application/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/ServiceLinkMapperTest.java
@@ -139,7 +139,8 @@ class ServiceLinkMapperTest {
       quayIdByStopPointRef,
       stopsById,
       issueStore,
-      150
+      150,
+      0.0
     );
   }
 

--- a/application/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
+++ b/application/src/test/java/org/opentripplanner/netex/mapping/TripPatternMapperTest.java
@@ -55,7 +55,8 @@ class TripPatternMapperTest {
       ArrayListMultimap.create(),
       Map.of(NetexTestDataSample.SERVICE_JOURNEY_ID, SERVICE_ID),
       new Deduplicator(),
-      150
+      150,
+      0.0
     );
 
     Optional<TripPatternMapperResult> res = tripPatternMapper.mapTripPattern(
@@ -193,7 +194,8 @@ class TripPatternMapperTest {
       sample.getDatedServiceJourneyBySjId(),
       Map.of(NetexTestDataSample.SERVICE_JOURNEY_ID, SERVICE_ID),
       new Deduplicator(),
-      150
+      150,
+      0.0
     );
 
     Optional<TripPatternMapperResult> res = tripPatternMapper.mapTripPattern(

--- a/application/src/test/java/org/opentripplanner/standalone/config/BuildConfigTest.java
+++ b/application/src/test/java/org/opentripplanner/standalone/config/BuildConfigTest.java
@@ -66,4 +66,28 @@ class BuildConfigTest {
     var conf = new BuildConfig(node, "Test", false);
     assertInstanceOf(JsonNode.class, conf.fareConfig);
   }
+
+  @Test
+  public void transitShapeSimplificationToleranceMetersDefaultsToDisabled() {
+    var node = jsonNodeForTest("{ }");
+    var subject = new BuildConfig(node, "Test", false);
+
+    assertEquals(0.0, subject.transitShapeSimplificationToleranceMeters());
+  }
+
+  @Test
+  public void transitShapeSimplificationToleranceMeters() {
+    var node = jsonNodeForTest("{ 'transitShapeSimplificationToleranceMeters' : 5.0 }");
+    var subject = new BuildConfig(node, "Test", false);
+
+    assertEquals(5.0, subject.transitShapeSimplificationToleranceMeters());
+  }
+
+  @Test
+  public void transitShapeSimplificationToleranceMetersClampsNegativeValueToZero() {
+    var node = jsonNodeForTest("{ 'transitShapeSimplificationToleranceMeters' : -5.0 }");
+    var subject = new BuildConfig(node, "Test", false);
+
+    assertEquals(0.0, subject.transitShapeSimplificationToleranceMeters());
+  }
 }

--- a/doc/user/BuildConfiguration.md
+++ b/doc/user/BuildConfiguration.md
@@ -45,6 +45,7 @@ Sections follow that describe particular settings in more depth.
 | [transitModelTimeZone](#transitModelTimeZone)                                               |      `time-zone`     | Time zone for the graph.                                                                                                                                       | *Optional* |                                   |  2.2  |
 | [transitServiceEnd](#transitServiceEnd)                                                     |      `duration`      | Limit the import of transit services to the given end date.                                                                                                    | *Optional* | `"P3Y"`                           |  2.0  |
 | [transitServiceStart](#transitServiceStart)                                                 |      `duration`      | Limit the import of transit services to the given START date.                                                                                                  | *Optional* | `"-P1Y"`                          |  2.0  |
+| [transitShapeSimplificationToleranceMeters](#transitShapeSimplificationToleranceMeters)     |       `double`       | Douglas-Peucker simplification tolerance for transit route shapes, in meters.                                                                                  | *Optional* |                                   |  2.11 |
 | [boardingLocationTags](#boardingLocationTags)                                               |      `string[]`      | What OSM tags should be looked on for the source of matching stops to platforms and stops.                                                                     | *Optional* |                                   |  2.2  |
 | [cache](#cache)                                                                             |       `object`       | Configuration for the graph-build file cache.                                                                                                                  | *Optional* |                                   |  2.10 |
 |    [enabled](#cache_enabled)                                                                |       `boolean`      | Master switch for the graph-build cache.                                                                                                                       | *Optional* | `false`                           |  2.10 |
@@ -641,6 +642,23 @@ will not be part of the graph. Use an absolute date or a period relative to the 
 build(BUILD_DAY).
 
 To get an effectively unbounded value, use a very large period like `"-P100Y"`.
+
+
+<h3 id="transitShapeSimplificationToleranceMeters">transitShapeSimplificationToleranceMeters</h3>
+
+**Since version:** `2.11` ∙ **Type:** `double` ∙ **Cardinality:** `Optional`   
+**Path:** / 
+
+Douglas-Peucker simplification tolerance for transit route shapes, in meters.
+
+Simplifies each trip pattern's shape geometry once, at graph-build time, using the
+Douglas-Peucker algorithm with this distance tolerance. A larger tolerance removes more
+points (and any shape detail smaller than it); points are never removed from an
+individual hop's endpoints, so stop locations are unaffected.
+
+This is opt-in - leave it unset to keep the raw, unsimplified shapes. A conservative
+starting point, if enabled, is a few meters: enough to remove excess shape-recording
+detail on long shapes without visibly straightening real curves.
 
 
 <h3 id="boardingLocationTags">boardingLocationTags</h3>

--- a/doc/user/BuildConfiguration.md
+++ b/doc/user/BuildConfiguration.md
@@ -45,7 +45,7 @@ Sections follow that describe particular settings in more depth.
 | [transitModelTimeZone](#transitModelTimeZone)                                               |      `time-zone`     | Time zone for the graph.                                                                                                                                       | *Optional* |                                   |  2.2  |
 | [transitServiceEnd](#transitServiceEnd)                                                     |      `duration`      | Limit the import of transit services to the given end date.                                                                                                    | *Optional* | `"P3Y"`                           |  2.0  |
 | [transitServiceStart](#transitServiceStart)                                                 |      `duration`      | Limit the import of transit services to the given START date.                                                                                                  | *Optional* | `"-P1Y"`                          |  2.0  |
-| [transitShapeSimplificationToleranceMeters](#transitShapeSimplificationToleranceMeters)     |       `double`       | Douglas-Peucker simplification tolerance for transit route shapes, in meters.                                                                                  | *Optional* |                                   |  2.11 |
+| [transitShapeSimplificationToleranceMeters](#transitShapeSimplificationToleranceMeters)     |       `double`       | Douglas-Peucker simplification tolerance for transit route shapes, in meters.                                                                                  | *Optional* | `0.0`                             |  2.11 |
 | [boardingLocationTags](#boardingLocationTags)                                               |      `string[]`      | What OSM tags should be looked on for the source of matching stops to platforms and stops.                                                                     | *Optional* |                                   |  2.2  |
 | [cache](#cache)                                                                             |       `object`       | Configuration for the graph-build file cache.                                                                                                                  | *Optional* |                                   |  2.10 |
 |    [enabled](#cache_enabled)                                                                |       `boolean`      | Master switch for the graph-build cache.                                                                                                                       | *Optional* | `false`                           |  2.10 |
@@ -646,19 +646,18 @@ To get an effectively unbounded value, use a very large period like `"-P100Y"`.
 
 <h3 id="transitShapeSimplificationToleranceMeters">transitShapeSimplificationToleranceMeters</h3>
 
-**Since version:** `2.11` ∙ **Type:** `double` ∙ **Cardinality:** `Optional`   
+**Since version:** `2.11` ∙ **Type:** `double` ∙ **Cardinality:** `Optional` ∙ **Default value:** `0.0`   
 **Path:** / 
 
 Douglas-Peucker simplification tolerance for transit route shapes, in meters.
 
-Simplifies each trip pattern's shape geometry once, at graph-build time, using the
-Douglas-Peucker algorithm with this distance tolerance. A larger tolerance removes more
-points (and any shape detail smaller than it); points are never removed from an
-individual hop's endpoints, so stop locations are unaffected.
+Simplifies each trip pattern's shape geometry once, at graph-build time, using the Douglas-Peucker
+algorithm with this distance tolerance. A larger tolerance removes more points (and any shape detail
+smaller than it); points are never removed from an individual hop's endpoints, so stop locations are
+unaffected.
 
-This is opt-in - leave it unset to keep the raw, unsimplified shapes. A conservative
-starting point, if enabled, is a few meters: enough to remove excess shape-recording
-detail on long shapes without visibly straightening real curves.
+This is opt-in - leave it unset to keep the raw, unsimplified shapes. 0.5 or 3.0 meters may save a
+significant amount of memory - if some of the feeds contains shapes with a lot of detail.
 
 
 <h3 id="boardingLocationTags">boardingLocationTags</h3>

--- a/street/src/main/java/org/opentripplanner/street/geometry/DouglasPeuckerAlgorithm.java
+++ b/street/src/main/java/org/opentripplanner/street/geometry/DouglasPeuckerAlgorithm.java
@@ -1,0 +1,126 @@
+package org.opentripplanner.street.geometry;
+
+import java.util.BitSet;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LineString;
+
+/**
+ * Simplifies a {@link LineString} with the Douglas-Peucker algorithm. A degree of longitude
+ * covers fewer real-world meters than a degree of latitude away from the equator, so the
+ * distance calculation scales longitude by {@code cos(latitude)} to correct for that - but only
+ * inside the distance calculation, never on the coordinates themselves. That means every
+ * retained point, endpoints included, is the exact original {@link Coordinate} instance: there is
+ * no scale/unscale round-trip, and so no rounding error that could move a point off its original
+ * location.
+ */
+public class DouglasPeuckerAlgorithm {
+
+  private final Coordinate[] coordinates;
+  private final double toleranceDegrees;
+  private final double lonScale;
+  private final BitSet keep;
+
+  private DouglasPeuckerAlgorithm(Coordinate[] coordinates, double toleranceMeters) {
+    this.coordinates = coordinates;
+    this.toleranceDegrees = SphericalDistanceLibrary.metersToDegrees(toleranceMeters);
+    this.lonScale = Math.cos(Math.toRadians(approximateAverageLatitude(coordinates)));
+    this.keep = new BitSet(coordinates.length);
+    this.keep.set(0);
+    this.keep.set(coordinates.length - 1);
+  }
+
+  /**
+   * Simplifies {@code lineString} to within {@code toleranceMeters}, keeping its first and last
+   * point exactly. A {@code toleranceMeters} of {@code 0} disables simplification.
+   *
+   * @throws IllegalArgumentException if {@code toleranceMeters} is negative.
+   */
+  public static LineString of(LineString lineString, double toleranceMeters) {
+    if (toleranceMeters < 0.0) {
+      throw new IllegalArgumentException("toleranceMeters must be greater than 0");
+    }
+    if (toleranceMeters == 0.0 || lineString.getNumPoints() < 3) {
+      return lineString;
+    }
+    var simplified = new DouglasPeuckerAlgorithm(
+      lineString.getCoordinates(),
+      toleranceMeters
+    ).simplify();
+    return simplified.length == lineString.getNumPoints()
+      ? lineString
+      : GeometryUtils.makeLineString(simplified);
+  }
+
+  /**
+   * Runs the algorithm and returns the simplified coordinates.
+   */
+  public Coordinate[] simplify() {
+    douglasPeucker(0, coordinates.length - 1);
+
+    int kept = keep.cardinality();
+    if (kept == coordinates.length) {
+      return coordinates;
+    }
+    Coordinate[] result = new Coordinate[kept];
+    int j = 0;
+    for (int i = 0; i < coordinates.length; i++) {
+      if (keep.get(i)) {
+        result[j] = coordinates[i];
+        ++j;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Keeps the point in {@code [start, end]} furthest from the chord between its endpoints if it
+   * exceeds {@code toleranceDegrees}, then recurses on both halves.
+   */
+  private void douglasPeucker(int start, int end) {
+    if (end <= start + 1) {
+      return;
+    }
+    double maxDistance = -1;
+    int maxIndex = -1;
+    for (int i = start + 1; i < end; i++) {
+      double distance = perpendicularDistance(coordinates[start], coordinates[end], coordinates[i]);
+      if (distance > maxDistance) {
+        maxDistance = distance;
+        maxIndex = i;
+      }
+    }
+    if (maxDistance > toleranceDegrees) {
+      keep.set(maxIndex);
+      douglasPeucker(start, maxIndex);
+      douglasPeucker(maxIndex, end);
+    }
+  }
+
+  /**
+   * Distance from {@code point} to the line through {@code start} and {@code end}, in degrees,
+   * with longitude scaled by {@link #lonScale}.
+   */
+  private double perpendicularDistance(Coordinate start, Coordinate end, Coordinate point) {
+    double x1 = start.x * lonScale;
+    double y1 = start.y;
+    double x2 = end.x * lonScale;
+    double y2 = end.y;
+    double px = point.x * lonScale;
+    double py = point.y;
+
+    double dx = x2 - x1;
+    double dy = y2 - y1;
+    if (dx == 0 && dy == 0) {
+      return Math.hypot(px - x1, py - y1);
+    }
+    return Math.abs(dy * px - dx * py + x2 * y1 - y2 * x1) / Math.hypot(dx, dy);
+  }
+
+  /**
+   * Approximates the line's average latitude from its first, middle and last point.
+   */
+  private static double approximateAverageLatitude(Coordinate[] coordinates) {
+    int lastIndex = coordinates.length - 1;
+    return (coordinates[0].y + coordinates[lastIndex / 2].y + coordinates[lastIndex].y) / 3;
+  }
+}

--- a/street/src/main/java/org/opentripplanner/street/geometry/GeometryUtils.java
+++ b/street/src/main/java/org/opentripplanner/street/geometry/GeometryUtils.java
@@ -27,6 +27,7 @@ import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 import org.locationtech.jts.linearref.LengthLocationMap;
 import org.locationtech.jts.linearref.LinearLocation;
 import org.locationtech.jts.linearref.LocationIndexedLine;
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 
 public class GeometryUtils {
 
@@ -67,6 +68,26 @@ public class GeometryUtils {
   public static LineString makeLineString(double... coords) {
     var seq = CSF.create(coords, 2);
     return GF.createLineString(seq);
+  }
+
+  /**
+   * Simplifies each line in {@code lineStrings} with the Douglas-Peucker algorithm, keeping the
+   * first and last point of every line exactly - safe to apply to a set of hop geometries whose
+   * endpoints must stay pinned to stop locations. A {@code toleranceMeters} of {@code 0} (or less)
+   * is treated as "disabled" and returns the input unchanged, so callers can wire this straight to
+   * an opt-in build-config parameter without a separate on/off check.
+   */
+  public static List<LineString> simplify(List<LineString> lineStrings, double toleranceMeters) {
+    if (toleranceMeters <= 0) {
+      return lineStrings;
+    }
+    double toleranceDegrees = SphericalDistanceLibrary.metersToDegrees(toleranceMeters);
+    return lineStrings
+      .stream()
+      .map(
+        lineString -> (LineString) DouglasPeuckerSimplifier.simplify(lineString, toleranceDegrees)
+      )
+      .toList();
   }
 
   public static LineString makeLineString(List<Coordinate> coordinates) {

--- a/street/src/main/java/org/opentripplanner/street/geometry/GeometryUtils.java
+++ b/street/src/main/java/org/opentripplanner/street/geometry/GeometryUtils.java
@@ -27,7 +27,6 @@ import org.locationtech.jts.geom.impl.PackedCoordinateSequenceFactory;
 import org.locationtech.jts.linearref.LengthLocationMap;
 import org.locationtech.jts.linearref.LinearLocation;
 import org.locationtech.jts.linearref.LocationIndexedLine;
-import org.locationtech.jts.simplify.DouglasPeuckerSimplifier;
 
 public class GeometryUtils {
 
@@ -68,26 +67,6 @@ public class GeometryUtils {
   public static LineString makeLineString(double... coords) {
     var seq = CSF.create(coords, 2);
     return GF.createLineString(seq);
-  }
-
-  /**
-   * Simplifies each line in {@code lineStrings} with the Douglas-Peucker algorithm, keeping the
-   * first and last point of every line exactly - safe to apply to a set of hop geometries whose
-   * endpoints must stay pinned to stop locations. A {@code toleranceMeters} of {@code 0} (or less)
-   * is treated as "disabled" and returns the input unchanged, so callers can wire this straight to
-   * an opt-in build-config parameter without a separate on/off check.
-   */
-  public static List<LineString> simplify(List<LineString> lineStrings, double toleranceMeters) {
-    if (toleranceMeters <= 0) {
-      return lineStrings;
-    }
-    double toleranceDegrees = SphericalDistanceLibrary.metersToDegrees(toleranceMeters);
-    return lineStrings
-      .stream()
-      .map(
-        lineString -> (LineString) DouglasPeuckerSimplifier.simplify(lineString, toleranceDegrees)
-      )
-      .toList();
   }
 
   public static LineString makeLineString(List<Coordinate> coordinates) {

--- a/street/src/test/java/org/opentripplanner/street/geometry/DouglasPeuckerAlgorithmTest.java
+++ b/street/src/test/java/org/opentripplanner/street/geometry/DouglasPeuckerAlgorithmTest.java
@@ -1,0 +1,83 @@
+package org.opentripplanner.street.geometry;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+
+class DouglasPeuckerAlgorithmTest {
+
+  private static final Coordinate BERLIN = new Coordinate(13.4105, 52.5212);
+  private static final Coordinate HAMBURG = new Coordinate(10.0003, 53.5566);
+  private static final Coordinate HANNOVER = new Coordinate(9.732, 52.376);
+
+  @Test
+  void simplifyDisabledWhenToleranceIsZero() {
+    var line = GeometryUtils.makeLineString(BERLIN, HAMBURG);
+    assertEquals(line, DouglasPeuckerAlgorithm.of(line, 0));
+  }
+
+  @Test
+  void simplifyRejectsNegativeTolerance() {
+    var zigzag = GeometryUtils.makeLineString(BERLIN, HAMBURG);
+    assertThrows(IllegalArgumentException.class, () -> DouglasPeuckerAlgorithm.of(zigzag, -5));
+  }
+
+  @Test
+  void simplifyRejectsDoesNothingForTwoPoints() {
+    var line = GeometryUtils.makeLineString(BERLIN, HAMBURG);
+    assertThat(DouglasPeuckerAlgorithm.of(line, 5)).isSameInstanceAs(line);
+  }
+
+  @Test
+  void simplifyReducesPointsButKeepsEndpoints() {
+    // A near-straight line with a tiny zigzag - well within a 50 m tolerance, so every
+    // interior point should be removable, leaving just the two endpoints.
+    var zigzag = GeometryUtils.makeLineString(BERLIN, HANNOVER, HAMBURG);
+    var line = DouglasPeuckerAlgorithm.of(zigzag, 50.0);
+
+    assertEquals(3, line.getNumPoints());
+    assertEquals(zigzag.getStartPoint().getCoordinate(), line.getStartPoint().getCoordinate());
+    assertEquals(zigzag.getEndPoint().getCoordinate(), line.getEndPoint().getCoordinate());
+
+    var simplified = DouglasPeuckerAlgorithm.of(zigzag, 250_000.0);
+
+    assertEquals(2, simplified.getNumPoints());
+    assertEquals(
+      zigzag.getStartPoint().getCoordinate(),
+      simplified.getStartPoint().getCoordinate()
+    );
+    assertEquals(zigzag.getEndPoint().getCoordinate(), simplified.getEndPoint().getCoordinate());
+  }
+
+  /// At 60 degrees latitude a degree of longitude covers about half as many meters as a degree
+  /// of latitude. A naive lat-only meters-to-degrees conversion would treat this east-west
+  /// zigzag (deliberately deviating in longitude only) as almost twice as far from the line as
+  /// it really is, and fail to simplify it despite the real-world deviation being well within
+  /// tolerance.
+  @Test
+  void simplifyAccountsForLongitudeDegreesShrinkingAwayFromEquator() {
+    var start = new Coordinate(60.0, 60.0);
+    var end = new Coordinate(62.0, 62.0);
+
+    var point = new Coordinate(61.0, 61.001);
+    var LINE = GeometryUtils.makeLineString(start, point, end);
+    assertThat(DouglasPeuckerAlgorithm.of(LINE, 48.50).getCoordinates())
+      .asList()
+      .containsExactly(start, point, end);
+    assertThat(DouglasPeuckerAlgorithm.of(LINE, 48.51).getCoordinates())
+      .asList()
+      .containsExactly(start, end);
+
+    point = new Coordinate(61.001, 61.0);
+    LINE = GeometryUtils.makeLineString(start, point, end);
+    assertThat(DouglasPeuckerAlgorithm.of(LINE, 48.50).getCoordinates())
+      .asList()
+      .containsExactly(start, point, end);
+    assertThat(DouglasPeuckerAlgorithm.of(LINE, 48.51).getCoordinates())
+      .asList()
+      .containsExactly(start, end);
+  }
+}

--- a/street/src/test/java/org/opentripplanner/street/geometry/GeometryUtilsTest.java
+++ b/street/src/test/java/org/opentripplanner/street/geometry/GeometryUtilsTest.java
@@ -10,13 +10,13 @@ import org.locationtech.jts.geom.CoordinateSequenceFactory;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 
-public class GeometryUtilsTest {
+class GeometryUtilsTest {
 
-  public static final Coordinate BERLIN = new Coordinate(13.4105, 52.5212);
-  public static final Coordinate HAMBURG = new Coordinate(10.0003, 53.5566);
+  private static final Coordinate BERLIN = new Coordinate(13.4105, 52.5212);
+  private static final Coordinate HAMBURG = new Coordinate(10.0003, 53.5566);
 
   @Test
-  public final void testSplitGeometryAtFraction() {
+  final void testSplitGeometryAtFraction() {
     Coordinate[] coordinates = new Coordinate[4];
 
     coordinates[0] = new Coordinate(0, 0);
@@ -258,26 +258,5 @@ public class GeometryUtilsTest {
     );
     var meters = GeometryUtils.sumDistances(multiPoint);
     assertEquals(255_384.0, meters, 0.5);
-  }
-
-  @Test
-  void simplifyDisabledWhenToleranceIsZeroOrLess() {
-    var zigzag = GeometryUtils.makeLineString(0, 0, 0.00001, 1, 0, 2, 0.00001, 3, 0, 4);
-    assertEquals(List.of(zigzag), GeometryUtils.simplify(List.of(zigzag), 0));
-    assertEquals(List.of(zigzag), GeometryUtils.simplify(List.of(zigzag), -5));
-  }
-
-  @Test
-  void simplifyReducesPointsButKeepsEndpoints() {
-    // A near-straight line with a tiny zigzag - well within a 50 m tolerance, so every
-    // interior point should be removable, leaving just the two endpoints.
-    var zigzag = GeometryUtils.makeLineString(0, 0, 0.00001, 0.5, 0, 1, 0.00001, 1.5, 0, 2);
-    var simplified = GeometryUtils.simplify(List.of(zigzag), 50);
-
-    assertEquals(1, simplified.size());
-    var line = simplified.get(0);
-    assertEquals(2, line.getNumPoints());
-    assertEquals(zigzag.getStartPoint().getCoordinate(), line.getStartPoint().getCoordinate());
-    assertEquals(zigzag.getEndPoint().getCoordinate(), line.getEndPoint().getCoordinate());
   }
 }

--- a/street/src/test/java/org/opentripplanner/street/geometry/GeometryUtilsTest.java
+++ b/street/src/test/java/org/opentripplanner/street/geometry/GeometryUtilsTest.java
@@ -259,4 +259,25 @@ public class GeometryUtilsTest {
     var meters = GeometryUtils.sumDistances(multiPoint);
     assertEquals(255_384.0, meters, 0.5);
   }
+
+  @Test
+  void simplifyDisabledWhenToleranceIsZeroOrLess() {
+    var zigzag = GeometryUtils.makeLineString(0, 0, 0.00001, 1, 0, 2, 0.00001, 3, 0, 4);
+    assertEquals(List.of(zigzag), GeometryUtils.simplify(List.of(zigzag), 0));
+    assertEquals(List.of(zigzag), GeometryUtils.simplify(List.of(zigzag), -5));
+  }
+
+  @Test
+  void simplifyReducesPointsButKeepsEndpoints() {
+    // A near-straight line with a tiny zigzag - well within a 50 m tolerance, so every
+    // interior point should be removable, leaving just the two endpoints.
+    var zigzag = GeometryUtils.makeLineString(0, 0, 0.00001, 0.5, 0, 1, 0.00001, 1.5, 0, 2);
+    var simplified = GeometryUtils.simplify(List.of(zigzag), 50);
+
+    assertEquals(1, simplified.size());
+    var line = simplified.get(0);
+    assertEquals(2, line.getNumPoints());
+    assertEquals(zigzag.getStartPoint().getCoordinate(), line.getStartPoint().getCoordinate());
+    assertEquals(zigzag.getEndPoint().getCoordinate(), line.getEndPoint().getCoordinate());
+  }
 }


### PR DESCRIPTION
### Summary

Adds an **opt-in** Douglas-Peucker simplification pass for transit route shapes, applied once at
graph-build time, to reduce the point count of dense shapes without visibly altering their path. We recommend pushing back on poor data quality, but a feed might serve multiple clients (travel planning might be just one), so it might be the case that a higher resolution geometry for shapes is needed. **This is a simple filter, the best quality is achieved by producing it where the input data is available.**

> Note! The Douglas-Peucker simplification implemented in OTP support WGTS coordinates, the JTS library we use also implement the Douglas-Peucker, but WGTS coordinates is not supported. 
 
**Build Config**
```
{ ... 
  "transitShapeSimplificationToleranceMeters" : 1.0
}  
```
Adding the above parameter to the build-config will enable the feature and remove coordinates where the shape is is close to a straight line.

### Issue

🟥 There is no issue for this — found while investigating transfer location, plotting hundreds of itineraries in a map. The client crashed because of the high density paths present in the Norwegian Netex data set.

- New class **`street/geometry/DouglasPeuckerAlgorithm`** implements Douglas-Peucker itself, rather than wrapping JTS's `DouglasPeuckerSimplifier`. This is necessary because a degree of longitude covers fewer real-world meters than a degree of latitude away from the equator — a plain meters-to-degrees conversion applied uniformly to both axes would make the effective tolerance vary with a hop's bearing and latitude. The perpendicular-distance calculation scales longitude by `cos(latitude)` (latitude approximated from the line's first, middle and last point), but **only inside that calculation, never on the coordinates themselves** — so every retained point endpoints included, is the exact original `Coordinate` instance from the input.
- Applied identically to both import paths, each hop's `LineString` simplified independently right where the hop geometries are first built. **Ideally this should be a separate messurable step in the build process, but due to poor design this is not possible. Changing the design is a bigger task and out of scope for this PR.** The implementation is encapsulated the best way I can, and can be split out as a separate step later, if the design is fixed.
- Simplifying each hop independently (rather than the whole pattern shape at once) is safe because Douglas-Peucker always preserves a line's first and last point.
- This only affects the **stored/served shape geometry** used for rendering — it runs once at build time, before the graph is serialized, and has no effect on routing/Raptor itself.

Measured the tolerance/reduction trade-off on a full production graph build (Norway, combined
NeTEx + GTFS, 678,112 hops, 43,431,475 original points) before picking a value to recommend:

| Tolerance | Point reduction |
|---|---|
| 0.5 m | 41.8% |
| 1 m | 53.8% |
| 2 m | 64.9% |
| 3 m | 70.9% |
| 4 m | 74.6% |
| 5 m | 77.2% |
| 10 m | 83.7% |
| 15 m | 86.6% |
| 20 m | 88.3% |
| 25 m | 89.5% |

**1-2 meters** looks like a good conservative starting point — a large majority of points removed
without visibly straightening real curves. Reduction varies noticeably by data source, so the right
value will depend on the feed.

### Full graph-build benchmark (Norway, feature off vs. several tolerances)

Built the full production Norway graph to isolate the effect of the feature on the graph-build step:

| Tolerance | `graph.obj` size | Δ size | Wall time | Peak build memory (max RSS) |
|---|---|---|---|---|
| off (default) | 2152.2 MiB | - | 182.5 s | 32.57 GiB |
| 0.5 m | 2095.3 MiB | -2.65% | 181.3 s | 32.24 GiB |
| 1 m | 2079.4 MiB | -3.38% | 179.9 s | 27.58 GiB |
| 3 m | 2055.0 MiB | -4.52% | 180.9 s | 31.06 GiB |
| 5 m | 2046.6 MiB | -4.91% | 184.8 s | 29.76 GiB |

All five builds produced **identical graph topology** — `|V|=3,383,587 |E|=8,125,548`,
`|Stops|=103,882 |Patterns|=30,933 |ConstrainedTransfers|=76,466` in every case — confirming the feature only changes shape-geometry content, not routing structure. Wall time is unaffected by the tolerance (179.9-184.8 s, no trend, just run-to-run noise); peak build memory is noisy too (GC timing-dependent) and doesn't show a clean trend either. The size reduction is real and
monotonically increasing with tolerance, but with diminishing returns above ~3 m for this dataset
- consistent with the per-hop-point-reduction numbers measured earlier in this doc.

The feature is worth it for feeds with very shape-heavy data, proportionally less so for others. 

> Note! Very high density shapes may affect the clients rendering these more than it affect the OTP server - worth keeping in mind. Shapes are pass-through-information in OTP.

### Unit tests

✅ New `DouglasPeuckerAlgorithmTest`:
- tolerance `0` is a no-op (returns an equal/unchanged line); negative tolerance throws
  `IllegalArgumentException`.
- a line with fewer than 3 points is returned as the *same instance* (nothing to simplify).
- a near-straight zigzag: the interior point is removed at a large tolerance while both endpoints
  are preserved exactly, and kept at a small tolerance.
- a regression test for the latitude-scaling fix: at 60°N, an east-west deviation and a
  north-south deviation of matching magnitude are simplified identically at the same tolerance,
  proving the longitude/latitude distance calculation is corrected rather than treating both axes
  as equal-width degrees.

✅ New `BuildConfigTest` cases.


### Documentation

✅ Java doc and config

### Changelog

✅ This is a new small opt-in feature.

### Bumping the serialization version id

✅ The Build config is changed.
